### PR TITLE
feat(ios): foregroundPresentationOptions

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -56,23 +56,23 @@
   if (notifeeNotification != nil) {
     UNNotificationPresentationOptions presentationOptions = 0;
     NSNumber *importance = notifeeNotification[@"ios"][@"importance"];
-    NSDictionary * foregroundPresentationOptions = notifeeNotification[@"ios"][@"foregroundPresentationOptions"];
+    NSDictionary *foregroundPresentationOptions = notifeeNotification[@"ios"][@"foregroundPresentationOptions"];
       
     BOOL alert = foregroundPresentationOptions[@"alert"];
     BOOL badge = foregroundPresentationOptions[@"badge"];
     BOOL sound = foregroundPresentationOptions[@"sound"];
       
-      if(badge){
-        presentationOptions += UNNotificationPresentationOptionBadge;
-      }
-      
-      if(sound){
-        presentationOptions += UNNotificationPresentationOptionSound;
-      }
-      
-      if(alert){
-        presentationOptions += UNNotificationPresentationOptionAlert;
-      }
+    if(badge) {
+      presentationOptions += UNNotificationPresentationOptionBadge;
+    }
+    
+    if(sound) {
+      presentationOptions += UNNotificationPresentationOptionSound;
+    }
+    
+    if(alert) {
+      presentationOptions += UNNotificationPresentationOptionAlert;
+    }
 
     completionHandler(presentationOptions);
   }


### PR DESCRIPTION
- removes the use of importance as a factor in influencing `badge`, `alert` & `sound` options for foreground notifications.
- uses props passed in by user for `badge`, `alert` & `sound`.
- Needs to be merged with this PR: https://github.com/notifee/react-native-notifee/pull/59/files