### PR TITLE
fix(android): defaults fix for API < 26

### DIFF
--- a/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -55,6 +55,7 @@ class NotificationManager {
      */
     Callable<NotificationCompat.Builder> builderCallable =
         () -> {
+          Boolean hasCustomSound = false;
           NotificationCompat.Builder builder =
               new NotificationCompat.Builder(
                   ContextHolder.getApplicationContext(), androidModel.getChannelId());
@@ -130,6 +131,7 @@ class NotificationManager {
           if (androidModel.getSound() != null) {
             Uri soundUri = ResourceUtils.getSoundUri(androidModel.getSound());
             if (soundUri != null) {
+              hasCustomSound = true;
               builder.setSound(soundUri);
             } else {
               Logger.w(
@@ -139,8 +141,7 @@ class NotificationManager {
             }
           }
 
-          builder.setDefaults(androidModel.getDefaults());
-
+          builder.setDefaults(androidModel.getDefaults(hasCustomSound));
           builder.setOngoing(androidModel.getOngoing());
           builder.setOnlyAlertOnce(androidModel.getOnlyAlertOnce());
           builder.setPriority(androidModel.getPriority());

--- a/android/src/main/java/app/notifee/core/model/NotificationAndroidModel.java
+++ b/android/src/main/java/app/notifee/core/model/NotificationAndroidModel.java
@@ -133,12 +133,16 @@ public class NotificationAndroidModel {
   /**
    * Gets the notification defaults (for API < 26)
    *
+   * @param hasCustomSound A flag to indicate if notificaiton has a custom sound and has successfuly
+   *     resolved
    * @return Integer
    */
-  public Integer getDefaults() {
+  public Integer getDefaults(Boolean hasCustomSound) {
+    String TAG = "NotificationManager";
+    Integer defaults = null;
+
     if (mNotificationAndroidBundle.containsKey("defaults")) {
       ArrayList<Integer> defaultsArray = mNotificationAndroidBundle.getIntegerArrayList("defaults");
-      Integer defaults = null;
 
       for (Integer integer : Objects.requireNonNull(defaultsArray)) {
         if (defaults == null) {
@@ -147,15 +151,23 @@ public class NotificationAndroidModel {
           defaults |= integer;
         }
       }
-
-      if (defaults != null) return defaults;
+    } else {
+      defaults = Notification.DEFAULT_ALL;
     }
 
-    if (mNotificationAndroidBundle.containsKey("sound")) {
-      return Notification.DEFAULT_VIBRATE | Notification.DEFAULT_LIGHTS;
+    if (hasCustomSound) {
+      defaults &= ~Notification.DEFAULT_SOUND;
     }
 
-    return Notification.DEFAULT_ALL;
+    if (!mNotificationAndroidBundle.containsKey("vibrationPattern")) {
+      defaults &= ~Notification.DEFAULT_VIBRATE;
+    }
+
+    if (mNotificationAndroidBundle.containsKey("lights")) {
+      defaults &= ~Notification.DEFAULT_LIGHTS;
+    }
+
+    return defaults;
   }
 
   /**

--- a/android/src/main/java/app/notifee/core/utility/ResourceUtils.java
+++ b/android/src/main/java/app/notifee/core/utility/ResourceUtils.java
@@ -182,7 +182,7 @@ public class ResourceUtils {
       return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
     } else {
       int soundResourceId = getResourceIdByName(sound, "raw");
-      if (soundResourceId == 0) {
+      if (soundResourceId == 0 && sound.contains(".")) {
         soundResourceId = getResourceIdByName(sound.substring(0, sound.lastIndexOf('.')), "raw");
       }
 


### PR DESCRIPTION
For API < 26 to allow custom sounds, lights and vibrations to be set. 
If custom sound fails to resolve, will fallback to `defaults`. 
No need to check if `vibrationPattern` or `lights` resolve, only that a custom value exists in the `notificationBundle`, to be able to overwrite the `defaults`.

This covers the following:
Scenario 1:
Defaults default to 'All', custom sound resolves which will remove 'Sound' from defaults, and custom sound will play.
```
notification: {
 android: {
  sound: 'horse',
 }
}
```
Scenario 2:
Defaults set to 'Lights', custom sound resolves and plays.
```
notification: {
 android: {
  sound: 'horse',
  defaults: [Lights]
 }
}
```

Scenario 3:
Sound doesn't resolve, but because user has set defaults and has not included 'Sound' there will no sound all together.
```
notification: {
 android: {
  sound: 'invalid',
  defaults: [Lights]
 }
}
```
Scenario 4:
Sound doesn't resolve, user has set defaults and included 'Sound', default sound will play.
```
notification: {
 android: {
  sound: 'invalid',
  defaults: [Lights, Sound]
 }
}
```

