### PR TITLE
fix(ios): send delivered event when trigger notification in foreground

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -99,7 +99,7 @@ struct {
     if (notifeeTrigger != nil) {
       // post DELIVERED event
       [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
-        @"type" : @3,  // DELIVERED = 3
+        @"type" : @(NotifeeCoreEventTypeDelivered),
         @"detail" : @{
           @"notification" : notifeeNotification,
         }

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -95,7 +95,7 @@
            withCompletionHandler:^(NSError *error) {
              if (error == nil) {
                [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
-                 @"type" : @3,  // DELIVERED = 3
+                 @"type" : @(NotifeeCoreEventTypeDelivered),
                  @"detail" : @{
                    @"notification" : notification,
                  }
@@ -131,7 +131,7 @@
            withCompletionHandler:^(NSError *error) {
              if (error == nil) {
                [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
-                 @"type" : @7,  // TRIGGER_NOTIFICATION_CREATED = 7
+                 @"type" : @(NotifeeCoreEventTypeTriggerNotificationCreated),
                  @"detail" : @{
                    @"notification" : notification,
                  }

--- a/ios/NotifeeCore/Private/NotifeeCoreUtil.h
+++ b/ios/NotifeeCore/Private/NotifeeCoreUtil.h
@@ -13,6 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *kNotifeeUserInfoNotification = @"__notifee_notification";
+static NSString *kNotifeeUserInfoTrigger = @"__notifee_trigger";
 
 // TimeUnit constants for IntervalTrigger
 static NSString *kNotifeeCoreTimeUnitSeconds = @"SECONDS";

--- a/ios/NotifeeCore/Public/NotifeeCore.h
+++ b/ios/NotifeeCore/Public/NotifeeCore.h
@@ -35,6 +35,11 @@ typedef NS_ENUM(NSInteger, NotifeeCoreNotificationType) {
   NotifeeCoreNotificationTypeTrigger = 2
 };
 
+typedef NS_ENUM(NSInteger, NotifeeCoreEventType) {
+  NotifeeCoreEventTypeDelivered = 3,
+  NotifeeCoreEventTypeTriggerNotificationCreated = 7,
+};
+
 @class NotifeeCore;
 
 @protocol NotifeeCoreDelegate <NSObject>


### PR DESCRIPTION
This fires the 'DELIVERED' event in foreground. Think there may still be differences with Android.  As I believe Android sends this event in background too. Changes to support the event in background will probably overlap with the FCM Integration work. 