### PR TITLE
fix(android): work manager fallback for trigger notifications created prior to room db

### DIFF
--- a/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -527,9 +527,9 @@ class NotificationManager {
         task -> {
           WorkDataEntity workDataEntity = task.getResult();
 
-          byte[] notificationBytes = workDataEntity.getNotification();
+          byte[] notificationBytes;
 
-          if (workDataEntity == null || notificationBytes == null) {
+          if (workDataEntity == null || workDataEntity.getNotification() == null) {
             // check if notification bundle is stored with Work Manager
             notificationBytes = data.getByteArray("notification");
             if (notificationBytes != null) {
@@ -543,6 +543,8 @@ class NotificationManager {
               completer.set(ListenableWorker.Result.success());
               return null;
             }
+          } else {
+            notificationBytes = workDataEntity.getNotification();
           }
 
           NotificationModel notificationModel =


### PR DESCRIPTION
Handle trigger notifications created prior to room db.
This logs a warning to the developer, and continues to display the notification..
Other alternative is to do the migrations in-house and move them over to room db.