### PR TITLE
fix(android): ensure fresco is initialized before accessing image pipeline

### DIFF
--- a/android/src/main/java/app/notifee/core/utility/ResourceUtils.java
+++ b/android/src/main/java/app/notifee/core/utility/ResourceUtils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.util.Log;
 import android.util.TypedValue;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -83,6 +84,14 @@ public class ResourceUtils {
     }
 
     ImageRequest imageRequest = ImageRequestBuilder.newBuilderWithSource(imageUri).build();
+
+    // Needed when the app is killed, and the Fresco hasn't yet been initialized by React Native
+    if (!Fresco.hasBeenInitialized()) {
+      Log.w(TAG, "Fresco initializing natively by Notifee");
+
+      // TODO(helenaford): expand on this to initialize with a custom imagePipelineConfig
+      Fresco.initialize(ContextHolder.getApplicationContext());
+    }
 
     DataSource<CloseableReference<CloseableImage>> dataSource =
         Fresco.getImagePipeline()


### PR DESCRIPTION
Fixes issue ([139](https://github.com/notifee/react-native-notifee/issues/139)) where largeIcon fails to load when the app is killed. 