### PR TITLE
feat(ios): send dismissed event when notification is cleared

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -127,7 +127,13 @@ struct {
   // we only care about notifications created through notifee
   if (notifeeNotification != nil) {
     if ([response.actionIdentifier isEqualToString:UNNotificationDismissActionIdentifier]) {
-      // TODO handle in a later version - sending a DISMISSED = 0 event to match Android
+        // post DISMISSED event, only triggers if notification has a categoryId
+        [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+            @"type" : @(NotifeeCoreEventTypeDismissed),
+            @"detail" : @{
+              @"notification" : notifeeNotification,
+            }
+          }];
       return;
     }
 

--- a/ios/NotifeeCore/Public/NotifeeCore.h
+++ b/ios/NotifeeCore/Public/NotifeeCore.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSInteger, NotifeeCoreNotificationType) {
 };
 
 typedef NS_ENUM(NSInteger, NotifeeCoreEventType) {
+  NotifeeCoreEventTypeDismissed = 0,
   NotifeeCoreEventTypeDelivered = 3,
   NotifeeCoreEventTypeTriggerNotificationCreated = 7,
 };


### PR DESCRIPTION
Only triggers `didReceiveNotificationResponse` if a notification has a category Id. 