### PR TITLE
fix(ios, build): set -o pipefail so that xcodebuild failures are surfaced

### DIFF
--- a/ios/build_xcframework.sh
+++ b/ios/build_xcframework.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 WORKING_DIR=$(pwd)
 FRAMEWORK_FOLDER_NAME="Notifee_XCFramework"


### PR DESCRIPTION

Since the xcodebuild failures are sent through a pipe to xcpretty, the exit code
is consumed by the pipe and xcpretty exit code wins. pipefail uses last non-zero
exit code in pipeline as exit code, so an xcodebuild failure results in non-zero exit
for the entire pipeline


https://www.translucentcomputing.com/2020/11/unofficial-bash-strict-mode-pipefail/