### PR TITLE
fix(ios): treat events when app is inactive as background events

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -99,7 +99,7 @@ struct {
     NSDictionary *notifeeTrigger = notification.request.content.userInfo[kNotifeeUserInfoTrigger];
     if (notifeeTrigger != nil) {
       // post DELIVERED event
-      [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+      [NotifeeCoreUtil didReceiveNotifeeCoreEvent:@{
         @"type" : @(NotifeeCoreEventTypeDelivered),
         @"detail" : @{
           @"notification" : notifeeNotification,
@@ -130,7 +130,7 @@ struct {
   if (notifeeNotification != nil) {
     if ([response.actionIdentifier isEqualToString:UNNotificationDismissActionIdentifier]) {
       // post DISMISSED event, only triggers if notification has a categoryId
-      [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+      [NotifeeCoreUtil didReceiveNotifeeCoreEvent:@{
         @"type" : @(NotifeeCoreEventTypeDismissed),
         @"detail" : @{
           @"notification" : notifeeNotification,
@@ -175,7 +175,7 @@ struct {
     _initialNotification = [eventDetail copy];
 
     // post PRESS/ACTION_PRESS event
-    [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:event];
+    [NotifeeCoreUtil didReceiveNotifeeCoreEvent:event];
 
     // TODO figure out if this is needed or if we can just complete immediately
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(15 * NSEC_PER_SEC)),

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -105,7 +105,7 @@
   [center addNotificationRequest:request
            withCompletionHandler:^(NSError *error) {
              if (error == nil) {
-               [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+               [NotifeeCoreUtil didReceiveNotifeeCoreEvent:@{
                  @"type" : @(NotifeeCoreEventTypeDelivered),
                  @"detail" : @{
                    @"notification" : notification,
@@ -142,7 +142,7 @@
   [center addNotificationRequest:request
            withCompletionHandler:^(NSError *error) {
              if (error == nil) {
-               [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+               [NotifeeCoreUtil didReceiveNotifeeCoreEvent:@{
                  @"type" : @(NotifeeCoreEventTypeTriggerNotificationCreated),
                  @"detail" : @{
                    @"notification" : notification,

--- a/ios/NotifeeCore/NotifeeCoreUtil.m
+++ b/ios/NotifeeCore/NotifeeCoreUtil.m
@@ -7,10 +7,11 @@
 //
 
 #import "Private/NotifeeCoreUtil.h"
-#import <UIKit/UIKit.h>
 #include <CoreGraphics/CGGeometry.h>
 #import <Intents/INIntentIdentifiers.h>
+#import <UIKit/UIKit.h>
 #import "Private/NotifeeCore+NSURLSession.h"
+#import "Private/NotifeeCoreDelegateHolder.h"
 
 @implementation NotifeeCoreUtil
 
@@ -560,6 +561,21 @@
  */
 + (NSString *)generateCachedFileName:(int)length {
   return [[NSUUID UUID] UUIDString];
+}
+
+/**
+ * Util to send an event with the foreground status of the application
+ */
++ (void)didReceiveNotifeeCoreEvent:(NSDictionary *)event {
+  [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:event
+                                                        foreground:[self isInForeground]];
+}
+
+/**
+ * Determines if application is in the foreground or not
+ */
++ (BOOL)isInForeground {
+  return [UIApplication sharedApplication].applicationState == UIApplicationStateActive;
 }
 
 /**

--- a/ios/NotifeeCore/Private/NotifeeCoreDelegateHolder.h
+++ b/ios/NotifeeCore/Private/NotifeeCoreDelegateHolder.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)instance;
 
-- (void)didReceiveNotifeeCoreEvent:(NSDictionary *)event;
+- (void)didReceiveNotifeeCoreEvent:(NSDictionary *)event foreground:(BOOL)foreground;
 
 @end
 

--- a/ios/NotifeeCore/Private/NotifeeCoreUtil.h
+++ b/ios/NotifeeCore/Private/NotifeeCoreUtil.h
@@ -53,6 +53,10 @@ typedef NS_ENUM(NSInteger, NotifeeCoreRepeatFrequency) {
 
 + (UNNotificationTrigger *)triggerFromDictionary:(NSDictionary *)triggerDict;
 
++ (void)didReceiveNotifeeCoreEvent:(NSDictionary *)event;
+
++ (BOOL)isInForeground;
+
 + (BOOL)isAppExtension;
 
 + (nullable instancetype)notifeeUIApplication;

--- a/ios/NotifeeCore/Public/NotifeeCore.h
+++ b/ios/NotifeeCore/Public/NotifeeCore.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSInteger, NotifeeCoreEventType) {
 
 @protocol NotifeeCoreDelegate <NSObject>
 @optional
-- (void)didReceiveNotifeeCoreEvent:(NSDictionary *_Nonnull)event;
+- (void)didReceiveNotifeeCoreEvent:(NSDictionary *_Nonnull)event foreground:(BOOL)foreground;
 @end
 
 @interface NotifeeCore : NSObject


### PR DESCRIPTION
TODO: look into the issue around events being delayed, think they both should be done together. 

Possibly a breaking change if users are expecting 'press' action on iOS to always be in the foreground, so should be in v2.