### PR TITLE
fix(android, alarm): avoid crash if receiving a non-Notifee alarm

### DIFF
--- a/android/src/main/java/app/notifee/core/NotifeeAlarmManager.java
+++ b/android/src/main/java/app/notifee/core/NotifeeAlarmManager.java
@@ -25,6 +25,9 @@ class NotifeeAlarmManager {
   private static final ExecutorService alarmManagerExecutor = Executors.newCachedThreadPool();
 
   static void displayScheduledNotification(Bundle alarmManagerNotification) {
+    if (alarmManagerNotification == null) {
+      return;
+    }
     String id = alarmManagerNotification.getString(NOTIFICATION_ID_INTENT_KEY);
 
     if (id == null) {


### PR DESCRIPTION

Crash reported in https://github.com/notifee/react-native-notifee/issues/330

```
Caused by java.lang.NullPointerException
Attempt to invoke virtual method 'java.lang.String android.os.BaseBundle.getString(java.lang.String)' on a null object reference

n.o.t.i.f.e.e.nZ_e.nz_n (SourceFile:20)
app.notifee.core.NotificationAlarmReceiver.onReceive (SourceFile:1)
android.app.ActivityThread.handleReceiver (ActivityThread.java:3390)
android.app.ActivityThread.-wrap18
android.app.ActivityThread$H.handleMessage (ActivityThread.java:1780)
android.os.Handler.dispatchMessage (Handler.java:105)
android.os.Looper.loop (Looper.java:164)
android.app.ActivityThread.main (ActivityThread.java:6938)
java.lang.reflect.Method.invoke (Method.java)
com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
```

There is only one instance of `Bundle.getString()` API being used in the file, so it must be the one just after the new lines I added.

- It can only be that the Bundle passed to our API here is null
- If we do not find a notifee key, we abort processing
- If the Bundle is null there is obviously no Notifee key, so aborting processing seems correct here as well

So I just added a null check