### PR TITLE
fix(android): remove JWT dependency, no longer needed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -112,7 +112,6 @@ dependencies {
   // Fresco 2.3.0+ may not be react-native compatible until 0.65.x with this: https://github.com/facebook/react-native/pull/30061
   // But! Fresco 2.2.0 is on JCenter and 2.3.0 is on mavenCentral - use 2.3.0 if you have to? https://github.com/facebook/fresco/issues/2585#issuecomment-822785614
   api 'com.facebook.fresco:fresco:2.2.0' // https://github.com/facebook/fresco/releases
-  api 'io.jsonwebtoken:jjwt-api:0.11.2' // https://github.com/jwtk/jjwt/releases
 
   def room_version = '2.3.0' // https://developer.android.com/jetpack/androidx/releases/room
   implementation "androidx.room:room-runtime:$room_version"

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -75,13 +75,6 @@ dependencies {
   // needed to enforce version and avoid clashes
   // https://github.com/square/okhttp/blob/master/docs/changelog_3x.md
   implementation 'com.squareup.okhttp3:okhttp:3.12.12' // okhttp must stay on 3.12.x to support minSdkVersion < 21
-
-  // https://github.com/jwtk/jjwt/releases
-  api 'io.jsonwebtoken:jjwt-api:0.11.2'
-  runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
-  runtimeOnly('io.jsonwebtoken:jjwt-orgjson:0.11.2') {
-    exclude group: 'org.json', module: 'json' //provided by Android natively
-  }
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/react-native/android/proguard-rules.pro
+++ b/packages/react-native/android/proguard-rules.pro
@@ -54,15 +54,6 @@
     public <init>(android.content.Context,androidx.work.WorkerParameters);
 }
 
-# JWT
--keep class io.jsonwebtoken.** { *; }
--keepnames class io.jsonwebtoken.* { *; }
--keepnames interface io.jsonwebtoken.* { *; }
-
--keep class org.bouncycastle.** { *; }
--keepnames class org.bouncycastle.** { *; }
--dontwarn org.bouncycastle.**
-
 # EventBus
 -keepclassmembers class * {
     @org.greenrobot.eventbus.Subscribe <methods>;


### PR DESCRIPTION
Fixes #184 most likely, since it was duplicate dependency on JWT and
we are not validating tokens anymore