### PR TITLE
fix(android, build-tools): use more backwards-compatible buildtools

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -53,7 +53,7 @@ android {
     }
   }
   compileSdkVersion = 31
-  buildToolsVersion = '31.0.0'
+  buildToolsVersion = '30.0.3'
 }
 
 repositories {


### PR DESCRIPTION
buildtools 31.0.0 only works with gradle 7+
using buildtools 30.0.3 should work with gradle plugin 4.2+ and gradle 7+

Fixes #211 based on feedback from the issue, this version should work