### PR TITLE
docs(CONTRIBUTING): update release checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,10 @@ Maintainers with write access to the repo and the npm organization can publish n
 1. Update release notes [here](https://github.com/invertase/notifee/blob/main/docs/react-native/docs/release-notes.md)
 1. Bump version: `npm version {minor/patch}`
 1. Tag the repo (current format is `@notifee/react-native@x.y.z`)
-1. Push the release notes / version / tag to the repo: 
-`git push --tags`
-`gh release create @notifee/react-native@x.y.z --title "@notifee/react-native@x.y.z" --notes "[Release Notes](https://notifee.app/react-native/docs/release-notes)"`
+1. Push the release notes / version / tag to the repo: `git push --tags`
+1. Create a release on the repo:
+    ```
+    gh release create @notifee/react-native@x.y.z --title "@notifee/react-native@x.y.z" --notes "[Release Notes](https://notifee.app/react-native/docs/release-notes)"
+    ```
 1. Publish to npm: `npm publish`
+1. Update the website with the new release notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,5 +86,7 @@ Maintainers with write access to the repo and the npm organization can publish n
 1. Update release notes [here](https://github.com/invertase/notifee/blob/main/docs/react-native/docs/release-notes.md)
 1. Bump version: `npm version {minor/patch}`
 1. Tag the repo (current format is `@notifee/react-native@x.y.z`)
-1. Push the release notes / version / tag to the repo: `git push --tags`
+1. Push the release notes / version / tag to the repo: 
+`git push --tags`
+`gh release create @notifee/react-native@x.y.z --title "@notifee/react-native@x.y.z" --notes "[Release Notes](https://notifee.app/react-native/docs/release-notes)"`
 1. Publish to npm: `npm publish`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,4 +92,3 @@ Maintainers with write access to the repo and the npm organization can publish n
     gh release create @notifee/react-native@x.y.z --title "@notifee/react-native@x.y.z" --notes "[Release Notes](https://notifee.app/react-native/docs/release-notes)"
     ```
 1. Publish to npm: `npm publish`
-1. Update the website with the new release notes


### PR DESCRIPTION
Added missing points to the release notes, including updating the website after we modify the docs.

Not sure how much detail to go into about redeploying the website. I think we could look into how we create a GitHub Action that auto-deploys when the docs directory is updated