### PR TITLE
test(e2e, ios): artifact uploads should not fail workflow

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -201,17 +201,20 @@ jobs:
 
       - name: Upload App Video
         uses: actions/upload-artifact@v2
+        continue-on-error: true
         if: always()
         with:
           name: simulator_video
           path: simulator.mp4
 
       - name: Compress Simulator Log
+        continue-on-error: true
         if: always()
         run: gzip -9 simulator.log
 
       - name: Upload Simulator Log
         uses: actions/upload-artifact@v2
+        continue-on-error: true
         if: always()
         with:
           name: simulator_logs
@@ -219,6 +222,7 @@ jobs:
 
       - name: Upload Packager Log
         uses: actions/upload-artifact@v2
+        continue-on-error: true
         if: always()
         with:
           name: packager_log


### PR DESCRIPTION
There was a failure where the ios simulator video took a 500 error when uploading.

That's interesting, but not in our control, so it should not fail the build.