### PR TITLE
feat(android): getNotificationSettings support

### DIFF
--- a/android/src/main/java/app/notifee/core/Notifee.java
+++ b/android/src/main/java/app/notifee/core/Notifee.java
@@ -27,6 +27,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 import app.notifee.core.event.InitialNotificationEvent;
 import app.notifee.core.event.MainComponentEvent;
 import app.notifee.core.interfaces.MethodCallResult;
@@ -378,6 +379,18 @@ public class Notifee {
   public void openPowerManagerSettings(Activity activity, MethodCallResult<Void> result) {
     PowerManagerUtils.openPowerManagerSettings(activity);
     result.onComplete(null, null);
+  }
+
+  @KeepForSdk
+  public void getNotificationSettings(MethodCallResult<Bundle> result) {
+    boolean areNotificationsEnabled = NotificationManagerCompat.from(ContextHolder.getApplicationContext()).areNotificationsEnabled();
+    Bundle notificationSettingsBundle = new Bundle();
+    if (areNotificationsEnabled) {
+      notificationSettingsBundle.putInt("alert", 1);
+    } else {
+      notificationSettingsBundle.putInt("alert", 0);
+    }
+    result.onComplete(null, notificationSettingsBundle);
   }
 
   @KeepForSdk

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -217,6 +217,13 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void getNotificationSettings(Promise promise) {
+    Notifee.getInstance()
+      .getNotificationSettings(
+        (e, aBundle) -> NotifeeReactUtils.promiseResolver(promise, e, aBundle));
+  }
+
+  @ReactMethod
   public void openNotificationSettings(String channelId, Promise promise) {
     Notifee.getInstance()
         .openNotificationSettings(

--- a/packages/react-native/src/NotifeeApiModule.ts
+++ b/packages/react-native/src/NotifeeApiModule.ts
@@ -462,22 +462,21 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
     permissions: IOSNotificationPermissions = {},
   ): Promise<IOSNotificationSettings> => {
     if (isAndroid) {
-      // Android doesn't require permission, so instead we
-      // return a dummy response to allow the permissions
-      // flow work the same on both iOS & Android
-      return Promise.resolve({
-        alert: 1,
-        badge: 1,
-        criticalAlert: 1,
-        showPreviews: 1,
-        sound: 1,
-        carPlay: 1,
-        lockScreen: 1,
-        announcement: 1,
-        notificationCenter: 1,
-        inAppNotificationSettings: 1,
-        authorizationStatus: 1,
-      } as IOSNotificationSettings);
+      return this.native.getNotificationSettings().then((alert: object) => {
+        return {
+          ...alert,
+          badge: 1,
+          criticalAlert: 1,
+          showPreviews: 1,
+          sound: 1,
+          carPlay: 1,
+          lockScreen: 1,
+          announcement: 1,
+          notificationCenter: 1,
+          inAppNotificationSettings: 1,
+          authorizationStatus: 1,
+        } as IOSNotificationSettings
+      })
     }
 
     let options: IOSNotificationPermissions;
@@ -537,22 +536,21 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
 
   public getNotificationSettings = (): Promise<IOSNotificationSettings> => {
     if (isAndroid) {
-      // Android doesn't support this, so instead we
-      // return a dummy response to allow the permissions
-      // flow work the same on both iOS & Android
-      return Promise.resolve({
-        alert: 1,
-        badge: 1,
-        criticalAlert: 1,
-        showPreviews: 1,
-        sound: 1,
-        carPlay: 1,
-        lockScreen: 1,
-        announcement: 1,
-        notificationCenter: 1,
-        inAppNotificationSettings: 1,
-        authorizationStatus: 1,
-      } as IOSNotificationSettings);
+      return this.native.getNotificationSettings().then((alert: object) => {
+        return {
+          ...alert,
+          badge: 1,
+          criticalAlert: 1,
+          showPreviews: 1,
+          sound: 1,
+          carPlay: 1,
+          lockScreen: 1,
+          announcement: 1,
+          notificationCenter: 1,
+          inAppNotificationSettings: 1,
+          authorizationStatus: 1,
+        } as IOSNotificationSettings
+      })
     }
 
     return this.native.getNotificationSettings();

--- a/packages/react-native/src/types/Module.ts
+++ b/packages/react-native/src/types/Module.ts
@@ -426,7 +426,8 @@ export interface Module {
    * Use the other `IOSNotificationSettings` properties to view which specific permissions were
    * allowed.
    *
-   * On Android, all of the properties on the `IOSNotificationSettings` interface response return
+   * On Android, `alert` will return `0` if permission is denied, `1` if permission is given.
+   * The rest of the properties on the `IOSNotificationSettings` interface response return
    * as `AUTHORIZED`.
    *
    * @platform ios
@@ -455,7 +456,8 @@ export interface Module {
   /**
    * Get the current notification settings for this application on the current device.
    *
-   * On Android, all of the properties on the `IOSNotificationSettings` interface response return
+   * On Android, `alert` will return `0` if permission is denied, `1` if permission is given.
+   * The rest of the properties on the `IOSNotificationSettings` interface response return
    * as `AUTHORIZED`.
    *
    * @platform ios

--- a/tests_react_native/__tests__/NotifeeApiModule.test.ts
+++ b/tests_react_native/__tests__/NotifeeApiModule.test.ts
@@ -233,4 +233,59 @@ describe('Notifee Api Module', () => {
       expect(mockNotifeeNativeModule.createChannel).not.toBeCalled();
     });
   });
+
+  describe('getNotificationSettings', () => {
+
+    describe('on Android', () => {
+      
+      beforeEach(() => {
+        setPlatform('android');
+      })
+
+      test('return alert 1 with the rest set to default values', async () => {
+        mockNotifeeNativeModule.getNotificationSettings.mockResolvedValue({
+          "alert": 1
+        })
+
+        const settings = await apiModule.getNotificationSettings()
+        
+        expect(settings).toEqual({
+          alert: 1,
+          badge: 1,
+          criticalAlert: 1,
+          showPreviews: 1,
+          sound: 1,
+          carPlay: 1,
+          lockScreen: 1,
+          announcement: 1,
+          notificationCenter: 1,
+          inAppNotificationSettings: 1,
+          authorizationStatus: 1,
+        })
+      });
+
+      test('return alert 0 with the rest set to default data', async () => {
+        mockNotifeeNativeModule.getNotificationSettings.mockResolvedValue({
+          "alert": 0
+        })
+
+        const settings = await apiModule.getNotificationSettings()
+        
+        expect(settings).toEqual({
+          alert: 0,
+          badge: 1,
+          criticalAlert: 1,
+          showPreviews: 1,
+          sound: 1,
+          carPlay: 1,
+          lockScreen: 1,
+          announcement: 1,
+          notificationCenter: 1,
+          inAppNotificationSettings: 1,
+          authorizationStatus: 1,
+        })
+      });
+
+    });
+  });
 });


### PR DESCRIPTION
Address https://github.com/invertase/notifee/issues/235

on Android, `getNotificationSettings` will return `alert` as `0` for permission denied and `1` for permission granted. This allows the library consumer to easily check if app level notification is enabled for Android on demand instead of settings up `onBackgroundEvent`. To preserve existing functionality, it will still returns `1` for the rest of the properties.

I added a unit test for the `getNotifcationSettings` for Android. However, I couldn't verify it works because I couldn't run the example app on my local machine with changes I made since it always point to the notifee github page for its dep. I will be more than happy to test it on emulator/simulator if someone could point me in the right direction.

Feel free to suggest fixes to the PR as well.