### PR TITLE
fix(android): auto cancel and close notification drawer when action is pressed

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-  <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" />
+  <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" android:maxSdkVersion="30" />
 
   <application>
     <!-- Receiver Service -->

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+  <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" />
 
   <application>
     <!-- Receiver Service -->

--- a/android/src/main/java/app/notifee/core/ReceiverService.java
+++ b/android/src/main/java/app/notifee/core/ReceiverService.java
@@ -209,15 +209,14 @@ public class ReceiverService extends Service {
           mainComponent,
           pressActionBundle.getLaunchActivityFlags());
 
-      // Close notification drawer with new action for Android 12
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        ContextHolder.getApplicationContext()
-          .sendBroadcast(new Intent(String.valueOf(GLOBAL_ACTION_DISMISS_NOTIFICATION_SHADE)));
-      } else {
+      int targetSdkVersion = ContextHolder.getApplicationContext().getApplicationInfo().targetSdkVersion;
+
+      // Close notification drawer if targetSdkVersion is Android 11 and lower
+      // See https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
+      if (targetSdkVersion < Build.VERSION_CODES.S ) {
         ContextHolder.getApplicationContext()
           .sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
       }
-
     }
   }
 

--- a/android/src/main/java/app/notifee/core/ReceiverService.java
+++ b/android/src/main/java/app/notifee/core/ReceiverService.java
@@ -17,6 +17,7 @@ package app.notifee.core;
  *
  */
 
+import static android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DISMISS_NOTIFICATION_SHADE;
 import static app.notifee.core.event.NotificationEvent.TYPE_ACTION_PRESS;
 import static app.notifee.core.event.NotificationEvent.TYPE_DISMISSED;
 import static app.notifee.core.event.NotificationEvent.TYPE_PRESS;
@@ -25,6 +26,7 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
@@ -206,8 +208,16 @@ public class ReceiverService extends Service {
           launchActivity,
           mainComponent,
           pressActionBundle.getLaunchActivityFlags());
-      ContextHolder.getApplicationContext()
+
+      // Close notification drawer with new action for Android 12
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        ContextHolder.getApplicationContext()
+          .sendBroadcast(new Intent(String.valueOf(GLOBAL_ACTION_DISMISS_NOTIFICATION_SHADE)));
+      } else {
+        ContextHolder.getApplicationContext()
           .sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
+      }
+
     }
   }
 

--- a/android/src/main/java/app/notifee/core/ReceiverService.java
+++ b/android/src/main/java/app/notifee/core/ReceiverService.java
@@ -28,10 +28,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.IBinder;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.RemoteInput;
 import app.notifee.core.event.InitialNotificationEvent;
 import app.notifee.core.event.MainComponentEvent;
 import app.notifee.core.event.NotificationEvent;
+import app.notifee.core.model.NotificationAndroidModel;
 import app.notifee.core.model.NotificationAndroidPressActionModel;
 import app.notifee.core.model.NotificationModel;
 import app.notifee.core.utility.IntentUtils;
@@ -168,6 +170,7 @@ public class ReceiverService extends Service {
     }
 
     NotificationModel notificationModel = NotificationModel.fromBundle(notification);
+    NotificationAndroidModel notificationAndroidModel = notificationModel.getAndroid();
     NotificationAndroidPressActionModel pressActionBundle =
         NotificationAndroidPressActionModel.fromBundle(pressAction);
 
@@ -184,6 +187,14 @@ public class ReceiverService extends Service {
 
     EventBus.post(new NotificationEvent(TYPE_ACTION_PRESS, notificationModel, extras));
 
+    if (notificationModel.getAndroid().getAutoCancel()) {
+      NotificationManagerCompat notificationManagerCompat =
+          NotificationManagerCompat.from(getApplicationContext());
+
+      notificationManagerCompat.cancel(
+          notificationAndroidModel.getTag(), notificationModel.getId().hashCode());
+    }
+
     String launchActivity = pressActionBundle.getLaunchActivity();
     String mainComponent = pressActionBundle.getMainComponent();
 
@@ -195,6 +206,8 @@ public class ReceiverService extends Service {
           launchActivity,
           mainComponent,
           pressActionBundle.getLaunchActivityFlags());
+      ContextHolder.getApplicationContext()
+          .sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
     }
   }
 

--- a/android/src/main/java/app/notifee/core/ReceiverService.java
+++ b/android/src/main/java/app/notifee/core/ReceiverService.java
@@ -17,7 +17,6 @@ package app.notifee.core;
  *
  */
 
-import static android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DISMISS_NOTIFICATION_SHADE;
 import static app.notifee.core.event.NotificationEvent.TYPE_ACTION_PRESS;
 import static app.notifee.core.event.NotificationEvent.TYPE_DISMISSED;
 import static app.notifee.core.event.NotificationEvent.TYPE_PRESS;


### PR DESCRIPTION
There's an issue currently where if an action is performed on a notification, the notification drawer remains open and the notification isn't canceled (unlike when a notification is pressed).

Closes https://github.com/invertase/notifee/issues/268

TODO:

Test on Android 12