### PR TITLE
fix(android): allow the projects to specify names of their apps

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -18,7 +18,11 @@ plugins {
   id "io.invertase.gradle.build" version "1.5"
 }
 
-project.evaluationDependsOn(':app')
+if (project.hasProperty('reactNativeProjects')) {
+  reactNativeProjects.each(dependent -> project.evaluationDependsOn(dependent))
+} else {
+  project.evaluationDependsOn(':app')
+}
 
 project.ext {
   set('react-native', [


### PR DESCRIPTION
1. The android app project name could be different than `:app`
2. There could be more than one app projects under android main projects

After this patch, one could specify a global variable `reactNativeProjects` in their project configuration and it should work in both the above situations.

e.g. I have 2 projects `:client` and `:server`

```gradle
buildscript {
    
    ext {
        // ...
        reactNativeProjects = [':client', ':server']
    }
  // ....
}
```