### PR TITLE
docs: [Notification Service Extension] Add a hint on required matching deployment target values

### DIFF
--- a/docs/react-native/docs/ios/remote-notification-support.md
+++ b/docs/react-native/docs/ios/remote-notification-support.md
@@ -16,7 +16,7 @@ To get started, you will need to implement a [Notification Service Extension](ht
 * From Xcode top menu go to: File > New > Target...
 * A modal will present a list of possible targets, scroll down or use the filter to select Notification Service Extension. Press Next.
 * Add a product name (use `NotifeeNotificationService` to follow along) and click Finish
-* Make sure that the **deployment target** of your newly added extension (e.g. `NotifeeNotificationService`) matches the **deployment target** of your app. You can check it by selecting you app's target -> Build Settings -> Deployment
+* Make sure that the **deployment target** of your newly added extension (e.g. `NotifeeNotificationService`) matches the **deployment target** of your app. You can check it by selecting you app's target -> `Build Settings` -> `Deployment`
 
 <!-- <Vimeo id="remote-notification-support-1" caption="Step 1 - Add Your Notification Service Extension" /> -->
 

--- a/docs/react-native/docs/ios/remote-notification-support.md
+++ b/docs/react-native/docs/ios/remote-notification-support.md
@@ -16,6 +16,7 @@ To get started, you will need to implement a [Notification Service Extension](ht
 * From Xcode top menu go to: File > New > Target...
 * A modal will present a list of possible targets, scroll down or use the filter to select Notification Service Extension. Press Next.
 * Add a product name (use `NotifeeNotificationService` to follow along) and click Finish
+* Make sure that the **deployment target** of your newly added extension (e.g. `NotifeeNotificationService`) matches the **deployment target** of your app. You can check it by selecting you app's target -> Build Settings -> Deployment
 
 <!-- <Vimeo id="remote-notification-support-1" caption="Step 1 - Add Your Notification Service Extension" /> -->
 


### PR DESCRIPTION
When implementing a Notification Service Extension, I run into an issue -> when following the steps from the documentation, the extension was not working for me.

What made the feature work for me, was setting the **deployments target** properties to the same values in both may app target and in newly created extension. Thus, I guess it would be nice to mention it to the users :) What do you think?

