### PR TITLE
fix(ios, permission): status key should be authorizationStatus

### DIFF
--- a/docs/react-native/docs/ios/permissions.md
+++ b/docs/react-native/docs/ios/permissions.md
@@ -101,7 +101,7 @@ async function checkApplicationPermission() {
 }
 ```
 
-The value of each setting in `settings.ios` returns a [`IOSNotificationSettings`](/reference/iosnotificationsettings) value, which can be
+The value of each setting in `settings.ios` returns a [`IOSNotificationSettings`](/react-native/reference/iosnotificationsettings) value, which can be
 one of three values:
 
 - `NOT_SUPPORTED`: The device either does not support the type of permission (the iOS API may be too low), or the permission has not been requested.

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -585,19 +585,19 @@
         NSMutableDictionary *settingsDictionary = [NSMutableDictionary dictionary];
         NSMutableDictionary *iosDictionary = [NSMutableDictionary dictionary];
 
-        // authorizedStatus
-        NSNumber *authorizedStatus = @-1;
+        // authorizationStatus
+        NSNumber *authorizationStatus = @-1;
         if (settings.authorizationStatus == UNAuthorizationStatusNotDetermined) {
-          authorizedStatus = @-1;
+          authorizationStatus = @-1;
         } else if (settings.authorizationStatus == UNAuthorizationStatusDenied) {
-          authorizedStatus = @0;
+          authorizationStatus = @0;
         } else if (settings.authorizationStatus == UNAuthorizationStatusAuthorized) {
-          authorizedStatus = @1;
+          authorizationStatus = @1;
         }
 
         if (@available(iOS 12.0, *)) {
           if (settings.authorizationStatus == UNAuthorizationStatusProvisional) {
-            authorizedStatus = @2;
+            authorizationStatus = @2;
           }
         }
 
@@ -634,7 +634,7 @@
         }
 
         iosDictionary[@"showPreviews"] = showPreviews;
-        iosDictionary[@"authorizationStatus"] = authorizedStatus;
+        iosDictionary[@"authorizationStatus"] = authorizationStatus;
         iosDictionary[@"alert"] =
             [NotifeeCoreUtil numberForUNNotificationSetting:settings.alertSetting];
         iosDictionary[@"badge"] =
@@ -648,7 +648,7 @@
         iosDictionary[@"notificationCenter"] =
             [NotifeeCoreUtil numberForUNNotificationSetting:settings.notificationCenterSetting];
 
-        settingsDictionary[@"authorizedStatus"] = authorizedStatus;
+        settingsDictionary[@"authorizationStatus"] = authorizationStatus;
         settingsDictionary[@"ios"] = iosDictionary;
 
         block(nil, settingsDictionary);

--- a/tests_react_native/ios/Podfile.lock
+++ b/tests_react_native/ios/Podfile.lock
@@ -358,10 +358,10 @@ PODS:
     - Firebase/Messaging (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNNotifee (4.1.0):
+  - RNNotifee (5.0.1):
     - NotifeeCore
     - React-Core
-  - RNNotifeeCore (4.1.0):
+  - RNNotifeeCore (5.0.1):
     - NotifeeCore
   - Yoga (1.14.0)
 
@@ -546,8 +546,8 @@ SPEC CHECKSUMS:
   ReactCommon: fda8de1535cec34971adef653f9afd954142eb7c
   RNFBApp: 729c0666395b1953198dc4a1ec6deb8fbe1c302e
   RNFBMessaging: 8415ec196e5c1196caa26ec0742cdb48ed4d0f97
-  RNNotifee: db0c45ad1eab8bf41e846b0e2121be2768f796f0
-  RNNotifeeCore: 79bd7f3bdaea136f685698f4069dcad0c57c3f31
+  RNNotifee: de2e3010396e318b255cf5af45d38e5d0be22551
+  RNNotifeeCore: 0b0cf012bae58dbe541872ba938e535d0fc45c3b
   Yoga: 63f25ad38b6f7597fa5dfee27088b29a01e83447
 
 PODFILE CHECKSUM: 5a8c08f65af9bf9f8543478056186aaf3b8e42ef

--- a/tests_react_native/ios/testing.xcodeproj/project.pbxproj
+++ b/tests_react_native/ios/testing.xcodeproj/project.pbxproj
@@ -571,7 +571,7 @@
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				INFOPLIST_FILE = testing/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -602,7 +602,7 @@
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				INFOPLIST_FILE = testing/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -737,7 +737,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
@@ -779,7 +779,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = Notifee;


### PR DESCRIPTION

This has three separate commits, each doing separate things with descriptive messages and conventional-commits-compliant titles

But the main one is that it Fixes #333 so I'm setting the PR title as that :-)

Basically it's setting the new app-wide notifications authorizationStatus key to the name we documented in the actual docs and in typescript, vs `authorizedStatus` which was not correct