### PR TITLE
feat(android): Add Android 13 notification permission to requestPermission

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,13 +38,13 @@ ext {
 }
 
 android {
-  compileSdkVersion 'android-Tiramisu'
+  compileSdkVersion 33
   testOptions {
     unitTests.returnDefaultValues = true
   }
   defaultConfig {
     minSdkVersion 20
-    targetSdkVersion 'android-Tiramisu'
+    targetSdkVersion 33
     versionCode 1
     versionName "1.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,13 +38,13 @@ ext {
 }
 
 android {
-  compileSdkVersion 31
+  compileSdkVersion 'android-Tiramisu'
   testOptions {
     unitTests.returnDefaultValues = true
   }
   defaultConfig {
     minSdkVersion 20
-    targetSdkVersion 30
+    targetSdkVersion 'android-Tiramisu'
     versionCode 1
     versionName "1.0"
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="app.notifee.core">
 
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/android/src/main/java/app/notifee/core/Notifee.java
+++ b/android/src/main/java/app/notifee/core/Notifee.java
@@ -19,6 +19,7 @@ package app.notifee.core;
 
 import static android.content.Intent.FLAG_ACTIVITY_NEW_TASK;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -27,6 +28,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationManagerCompat;
 import app.notifee.core.event.InitialNotificationEvent;
 import app.notifee.core.event.MainComponentEvent;
@@ -44,6 +46,8 @@ public class Notifee {
   private static final String TAG = "API";
   private static Notifee mNotifee = null;
   private static NotifeeConfig mNotifeeConfig = null;
+
+  public static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 11111;
 
   @KeepForSdk
   public static Notifee getInstance() {
@@ -411,6 +415,29 @@ public class Notifee {
     
     notificationSettingsBundle.putBundle("android", androidSettingsBundle);
     result.onComplete(null, notificationSettingsBundle);
+  }
+
+  @Nullable
+  private MethodCallResult<Bundle> requestPermissionCallResult;
+
+  @KeepForSdk
+  public void requestPermission(Activity activity, MethodCallResult<Bundle> result) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      requestPermissionCallResult = result;
+      ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQUEST_CODE_NOTIFICATION_PERMISSION);
+    } else {
+      getNotificationSettings(result);
+    }
+  }
+
+  public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    if (requestCode == REQUEST_CODE_NOTIFICATION_PERMISSION) {
+      if (requestPermissionCallResult != null) {
+        getNotificationSettings(requestPermissionCallResult);
+        return true;
+      }
+    }
+    return false;
   }
 
   @KeepForSdk

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -14,11 +14,12 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.modules.core.PermissionListener;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-public class NotifeeApiModule extends ReactContextBaseJavaModule {
+public class NotifeeApiModule extends ReactContextBaseJavaModule implements PermissionListener {
   private static final int NOTIFICATION_TYPE_DISPLAYED = 1;
   private static final int NOTIFICATION_TYPE_TRIGGER = 2;
   private static final int NOTIFICATION_TYPE_ALL = 0;
@@ -231,6 +232,14 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void requestPermission(Promise promise) {
+    Notifee.getInstance()
+      .requestPermission(
+        getCurrentActivity(),
+        (e, aBundle) -> NotifeeReactUtils.promiseResolver(promise, e, aBundle));
+  }
+
+  @ReactMethod
   public void openNotificationSettings(String channelId, Promise promise) {
     Notifee.getInstance()
         .openNotificationSettings(
@@ -300,4 +309,10 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule {
     constants.put("ANDROID_API_LEVEL", android.os.Build.VERSION.SDK_INT);
     return constants;
   }
+
+  @Override
+  public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    return Notifee.getInstance().onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+  
 }

--- a/packages/react-native/src/NotifeeApiModule.ts
+++ b/packages/react-native/src/NotifeeApiModule.ts
@@ -519,7 +519,7 @@ export default class NotifeeApiModule extends NotifeeNativeModule implements Mod
   ): Promise<NotificationSettings> => {
     if (isAndroid) {
       return this.native
-        .getNotificationSettings()
+        .requestPermission()
         .then(
           ({
             authorizationStatus,

--- a/tests_react_native/android/build.gradle
+++ b/tests_react_native/android/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     buildToolsVersion = '31.0.0'
     ndkVersion = "21.4.7075529"
     minSdkVersion = 21
-    compileSdkVersion = 'android-Tiramisu'
-    targetSdkVersion = 'Tiramisu'
+    compileSdkVersion = 33
+    targetSdkVersion = 33
     enableHermes = true
   }
 
@@ -65,11 +65,11 @@ subprojects {
   afterEvaluate { project ->
     if (!project.name.equalsIgnoreCase('app') && project.hasProperty('android')) {
       android {
-        compileSdkVersion 'android-Tiramisu'
+        compileSdkVersion 33
         buildToolsVersion buildTools
         defaultConfig {
           minSdkVersion minSdk
-          targetSdkVersion 'Tiramisu'
+          targetSdkVersion 33
         }
       }
     }

--- a/tests_react_native/android/build.gradle
+++ b/tests_react_native/android/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     buildToolsVersion = '31.0.0'
     ndkVersion = "21.4.7075529"
     minSdkVersion = 21
-    compileSdkVersion = 31
-    targetSdkVersion = 31
+    compileSdkVersion = 'android-Tiramisu'
+    targetSdkVersion = 'Tiramisu'
     enableHermes = true
   }
 
@@ -65,11 +65,11 @@ subprojects {
   afterEvaluate { project ->
     if (!project.name.equalsIgnoreCase('app') && project.hasProperty('android')) {
       android {
-        compileSdkVersion compileSdk
+        compileSdkVersion 'android-Tiramisu'
         buildToolsVersion buildTools
         defaultConfig {
           minSdkVersion minSdk
-          targetSdkVersion targetSdk
+          targetSdkVersion 'Tiramisu'
         }
       }
     }


### PR DESCRIPTION
### It is too early to merge this and it would be better to wait for Android 13 SDK to be stable first. This is a preemptive PR to make our upgrade easier to support Android 13

As per [Android 13 changes doc](https://developer.android.com/about/versions/13/changes/notification-permission), notification won't be allowed unless user give permission. App that targets 13 and above can now request permission in context to improve the app's user experience.

This PR modify `requestPermission` function to call this notification permission request if the device is on Android 13 and above.

Currently, due to known bug, you need to comment out the android os version check to test it on Android 13 dev preview emulator. But to demonstrate, I attached a gif below 

![notifee_gif](https://user-images.githubusercontent.com/8557241/159715246-3b575083-c1d7-47a9-864b-4a0a986137fb.gif)

Once Android 13 SDK  is stable, we need to do the followings:

- [ ] Replace `android-Tiramisu` & `Tiramisu` with correct sdk version.
- [ ] Revert the changes made to `afterEvaluate` in `test_react_native/android`
- [ ] Update docs with new behavior and add reference with links to android 13 change page
- [ ] Confirm it's working for Android 13 And below 13 device

Fixes #347 
