### PR TITLE
fix(android): ensure alarmManager notifications are cancelled

### DIFF
--- a/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -62,6 +62,7 @@ import app.notifee.core.utility.ObjectUtils;
 import app.notifee.core.utility.ResourceUtils;
 import app.notifee.core.utility.TextUtils;
 import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import java.util.ArrayList;
@@ -467,9 +468,14 @@ class NotificationManager {
             task -> {
               if (notificationType == NOTIFICATION_TYPE_TRIGGER
                   || notificationType == NOTIFICATION_TYPE_ALL) {
-                NotifeeAlarmManager.cancelAllNotifications();
-                // delete all from database
-                WorkDataRepository.getInstance(getApplicationContext()).deleteAll();
+                task.continueWith(NotifeeAlarmManager.cancelAllNotifications()).addOnSuccessListener(t -> {
+                    t.continueWith(a -> {
+                        // delete all from database after canceling the alarms
+                        WorkDataRepository.getInstance(getApplicationContext()).deleteAll();
+                        return null;
+                    });
+                });
+
               }
               return null;
             });


### PR DESCRIPTION
Hi,

I noticed that AlarmManager alarms are never getting canceled because `Continuation` object's tasks, in `NotifeeAlarmManager.cancelAllNotifications()`, is never running.

It's silently throwing errors (please see screenshot below) for the older Android versions and not causing big trouble because the data in local db is getting removed in `NotificationManager.cancelAllNotifications` , and the PN can not be sent without the data. However, it's causing to [this error](https://github.com/invertase/notifee/issues/349) for `Android >=12`.

Fixes #349

<img width="1109" alt="Screen Shot 2022-03-22 at 11 39 19" src="https://user-images.githubusercontent.com/16003411/159788678-f1bc5e4f-4eab-4524-8dc8-724308012707.png">

Hope this changes makes sense.