### PR TITLE
feat(web): basic support for react-native-web

### DIFF
--- a/packages/react-native/.npmignore
+++ b/packages/react-native/.npmignore
@@ -56,7 +56,6 @@ android/gradle/
 coverage
 yarn.lock
 e2e/
-src/
 .github
 .vscode
 .nyc_output
@@ -66,7 +65,6 @@ android/.settings
 .eslintignore
 android/libs/notifee_core_debug.aar
 .editorconfig
-tsconfig.json
 type-test.ts
 .prettierrc
 .eslintrc.js

--- a/packages/react-native/src/NotifeeNativeModule.web.ts
+++ b/packages/react-native/src/NotifeeNativeModule.web.ts
@@ -1,0 +1,25 @@
+import { EventEmitter, NativeEventEmitter, NativeModulesStatic } from 'react-native';
+
+export interface NativeModuleConfig {
+  version: string;
+  nativeModuleName: string;
+  nativeEvents: string[];
+}
+
+export default class NotifeeNativeModule {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore unused value
+  private readonly _moduleConfig: NativeModuleConfig;
+
+  public constructor(config: NativeModuleConfig) {
+    this._moduleConfig = Object.assign({}, config);
+  }
+
+  public get emitter(): EventEmitter {
+    return new NativeEventEmitter();
+  }
+
+  public get native(): NativeModulesStatic {
+    return {};
+  }
+}

--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -10,6 +10,7 @@ import {
   AndroidLaunchActivityFlag,
 } from './NotificationAndroid';
 import { AndroidNotificationSettings, Trigger } from '..';
+import { WebNotificationSettings } from './NotificationWeb';
 
 /**
  * Interface for building a local notification for both Android & iOS devices.
@@ -483,12 +484,17 @@ export interface NotificationSettings {
   authorizationStatus: AuthorizationStatus;
   /**
    * Overall notification settings for the application in iOS.
-   * On Android, this will be populated with default values
+   * On non-iOS platforms, this will be populated with default values
    */
   ios: IOSNotificationSettings;
   /**
    * Overall notification settings for the application in android.
-   * On iOS, this will be populated with default values
+   * On non-Android platforms, this will be populated with default values
    */
   android: AndroidNotificationSettings;
+  /**
+   * Overall notification settings for the application in web.
+   * On non-Web platforms, this will be populated with default values
+   */
+  web: WebNotificationSettings;
 }

--- a/packages/react-native/src/types/NotificationWeb.ts
+++ b/packages/react-native/src/types/NotificationWeb.ts
@@ -1,0 +1,5 @@
+/**
+ * Empty at the moment but will contain web-specific settings as needed
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WebNotificationSettings {}

--- a/packages/react-native/src/utils/index.ts
+++ b/packages/react-native/src/utils/index.ts
@@ -27,6 +27,8 @@ export const isIOS = Platform.OS === 'ios';
 
 export const isAndroid = Platform.OS === 'android';
 
+export const isWeb = Platform.OS === 'web';
+
 export function noop(): void {
   // noop-🐈
 }

--- a/packages/react-native/src/validators/validateAndroidNotification.ts
+++ b/packages/react-native/src/validators/validateAndroidNotification.ts
@@ -2,8 +2,7 @@
 /*
  * Copyright (c) 2016-present Invertase Limited
  */
-// @ts-ignore
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
+import { Image } from 'react-native';
 
 import {
   objectHasProperty,
@@ -301,7 +300,7 @@ export default function validateAndroidNotification(
     }
 
     if (isNumber(android.largeIcon) || isObject(android.largeIcon)) {
-      const image = resolveAssetSource(android.largeIcon);
+      const image = Image.resolveAssetSource(android.largeIcon);
       out.largeIcon = image.uri;
     } else {
       out.largeIcon = android.largeIcon;

--- a/packages/react-native/src/validators/validateAndroidStyle.ts
+++ b/packages/react-native/src/validators/validateAndroidStyle.ts
@@ -1,11 +1,7 @@
 /*
  * Copyright (c) 2016-present Invertase Limited
  */
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
-
+import { Image } from 'react-native';
 import {
   AndroidBigPictureStyle,
   AndroidBigTextStyle,
@@ -39,7 +35,7 @@ export function validateAndroidBigPictureStyle(
   };
 
   if (isNumber(style.picture) || isObject(style.picture)) {
-    const image = resolveAssetSource(style.picture);
+    const image = Image.resolveAssetSource(style.picture);
 
     out.picture = image.uri;
   }
@@ -56,7 +52,7 @@ export function validateAndroidBigPictureStyle(
       );
     }
     if (isNumber(style.largeIcon) || isObject(style.largeIcon)) {
-      const image = resolveAssetSource(style.largeIcon);
+      const image = Image.resolveAssetSource(style.largeIcon);
 
       out.largeIcon = image.uri;
     } else {

--- a/packages/react-native/src/validators/validateIOSAttachment.ts
+++ b/packages/react-native/src/validators/validateIOSAttachment.ts
@@ -4,7 +4,7 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
+import { Image } from 'react-native';
 
 import {
   generateId,
@@ -42,7 +42,7 @@ export default function validateIOSAttachment(
   };
 
   if (isNumber(attachment.url) || isObject(attachment.url)) {
-    const image = resolveAssetSource(attachment.url);
+    const image = Image.resolveAssetSource(attachment.url);
     out.url = image.uri;
   }
 

--- a/tests_react_native/__tests__/NotifeeApiModule.test.ts
+++ b/tests_react_native/__tests__/NotifeeApiModule.test.ts
@@ -269,6 +269,7 @@ describe('Notifee Api Module', () => {
             inAppNotificationSettings: 1,
             authorizationStatus: AuthorizationStatus.AUTHORIZED,
           },
+          web: {},
         });
       });
     });
@@ -278,9 +279,9 @@ describe('Notifee Api Module', () => {
         setPlatform('iOS');
       });
 
-      test('return iOS settings with AndroidNotificationSettings set to default values', async () => {
+      test('return web settings with AndroidNotificationSettings set to default values', async () => {
         mockNotifeeNativeModule.getNotificationSettings.mockResolvedValue({
-          authorizationStatus: AuthorizationStatus.AUTHORIZED,
+          authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
           ios: {
             alert: 1,
             badge: 1,
@@ -292,12 +293,13 @@ describe('Notifee Api Module', () => {
             announcement: 1,
             notificationCenter: 1,
             inAppNotificationSettings: 1,
-            authorizationStatus: AuthorizationStatus.AUTHORIZED,
+            authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
           },
+          web: {},
         });
         const settings = await apiModule.getNotificationSettings();
         expect(settings).toEqual({
-          authorizationStatus: AuthorizationStatus.AUTHORIZED,
+          authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
           android: {
             alarm: AndroidNotificationSetting.ENABLED,
           },
@@ -312,8 +314,9 @@ describe('Notifee Api Module', () => {
             announcement: 1,
             notificationCenter: 1,
             inAppNotificationSettings: 1,
-            authorizationStatus: AuthorizationStatus.AUTHORIZED,
+            authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
           },
+          web: {},
         });
       });
     });


### PR DESCRIPTION

There are no actual APIs productively implemented, however the structure for react-native-web support is in place now, and it builds correctly and runs on react-native-web without failures, so notifee may safely be included in react-native-web projects

Demonstration:
https://github.com/mikehardy/rnfbdemo/commit/d0f7ef9745ef0aa1981919562927cad66af298b5

Clean console from `yarn web` in `notifeewebdemo` on that commit of my demo script:
![image](https://user-images.githubusercontent.com/782704/162079360-75362b8e-abc7-45e0-a96f-e446ec61eb19.png)

As discussed in https://github.com/invertase/notifee/discussions/364 with @thecompoundingdev as well as on Slack with @yamankatby and @Ehesp 