### PR TITLE
fix(expo): increase compileSdkVersion to 31 and add EAS instructions to doc

### DIFF
--- a/docs/react-native/docs/installation.md
+++ b/docs/react-native/docs/installation.md
@@ -79,7 +79,7 @@ Then, add `@notifee/react-native` to the list of plugins in your app's Expo conf
 
 Finally, ensure you run `expo prebuild` and rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
-Please note that Notifee needs Java JDK 11+ to build on Android. If you are building the app with EAS, you need to change the image used for the build. You will have to use `image` as `ubuntu-18.04-jdk-11-ndk-r19c` or `latest` as in the following configuration. ([EAS Build Server Configuration](https://docs.expo.dev/build-reference/infrastructure/#image--ubuntu-1804-jdk-8-ndk-r19c--alias--default))
+Please note that Notifee needs Java JDK 11+ to build on Android. If you are building the app with EAS, you need to change the image used for the build. You will have to use `image` as `ubuntu-18.04-jdk-11-ndk-r19c` or another image that has jdk 11 as in the following configuration. ([EAS Build Server Configuration](https://docs.expo.dev/build-reference/infrastructure/#image--ubuntu-1804-jdk-8-ndk-r19c--alias--default))
 
 eas.json:
 ```json
@@ -89,7 +89,7 @@ eas.json:
       "developmentClient": true,
       "distribution": "internal",
       "android": {
-        "image": "latest"
+        "image": "ubuntu-18.04-jdk-11-ndk-r19c"
       }
     }
 }

--- a/docs/react-native/docs/installation.md
+++ b/docs/react-native/docs/installation.md
@@ -78,3 +78,19 @@ Then, add `@notifee/react-native` to the list of plugins in your app's Expo conf
 ```
 
 Finally, ensure you run `expo prebuild` and rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
+
+Please note that Notifee needs Java JDK 11+ to build on Android. If you are building the app with EAS, you need to change the image used for the build. You will have to use `image` as `ubuntu-18.04-jdk-11-ndk-r19c` or `latest` as in the following configuration. ([EAS Build Server Configuration](https://docs.expo.dev/build-reference/infrastructure/#image--ubuntu-1804-jdk-8-ndk-r19c--alias--default))
+
+eas.json:
+```json
+{
+  "build": {
+    "dev": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "image": "latest"
+      }
+    }
+}
+```

--- a/packages/react-native/plugin/__tests__/__snapshots__/androidProjectBuild.test.ts.snap
+++ b/packages/react-native/plugin/__tests__/__snapshots__/androidProjectBuild.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`[Android] project build.gradle test applies changes to project build.grade 1`] = `
+exports[`[Android] project build.gradle test adds custom maven repository to project build.gradle 1`] = `
 "// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {

--- a/packages/react-native/plugin/__tests__/__snapshots__/fullPlugin.test.ts.snap
+++ b/packages/react-native/plugin/__tests__/__snapshots__/fullPlugin.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expo plugin should run the plugin without error 1`] = `
+Object {
+  "_internal": Object {
+    "projectRoot": "dummy-path",
+  },
+  "mods": Object {
+    "android": Object {
+      "projectBuildGradle": [Function],
+    },
+  },
+  "name": "dummy",
+  "slug": "dummy",
+}
+`;

--- a/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
+++ b/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
@@ -3,34 +3,24 @@ import path from 'path';
 
 import { setCompileSdkVersion, setMavenRepository } from '../src/withNotifeeProjectGradlePlugin';
 
+const getProjectGradle = () => {
+  return fs.readFile(path.resolve(__dirname, './fixtures/project.build.gradle'), {
+    encoding: 'utf-8',
+  });
+};
+
 describe('[Android] project build.gradle test', () => {
   it('updates java compileSdkVersion to 31 in project build.gradle', async () => {
-    let projectGradle = await fs.readFile(
-      path.resolve(__dirname, '../fixtures/project.build.gradle'),
-      {
-        encoding: 'utf-8',
-      },
-    );
+    const projectGradle = await getProjectGradle();
+    const newProjectGradle = setCompileSdkVersion(projectGradle);
 
-    projectGradle = setCompileSdkVersion(projectGradle);
-
-    expect(projectGradle).toContain('compileSdkVersion = 31');
-
-    console.log(projectGradle);
+    expect(newProjectGradle).toContain('compileSdkVersion = 31');
   });
 
   it('adds custom maven repository to project build.gradle', async () => {
-    let projectGradle = await fs.readFile(
-      path.resolve(__dirname, '../fixtures/project.build.gradle'),
-      {
-        encoding: 'utf-8',
-      },
-    );
+    const projectGradle = await getProjectGradle();
+    const newProjectGradle = setMavenRepository(projectGradle);
 
-    projectGradle = setMavenRepository(projectGradle);
-
-    expect(projectGradle).toMatchSnapshot();
-
-    console.log(projectGradle);
+    expect(newProjectGradle).toMatchSnapshot();
   });
 });

--- a/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
+++ b/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { setCompileSdkVersion, setMavenRepository } from '../src/withNotifeeProjectGradlePlugin';
 
 describe('[Android] project build.gradle test', () => {
-  it('applies maven repository to project build.grade', async () => {
+  it('updates java compileSdkVersion to 31 in project build.gradle', async () => {
     let projectGradle = await fs.readFile(
       path.resolve(__dirname, '../fixtures/project.build.gradle'),
       {

--- a/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
+++ b/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
@@ -19,7 +19,7 @@ describe('[Android] project build.gradle test', () => {
     console.log(projectGradle);
   });
 
-  it('applies maven repository to project build.grade', async () => {
+  it('adds custom maven repository to project build.gradle', async () => {
     let projectGradle = await fs.readFile(
       path.resolve(__dirname, '../fixtures/project.build.gradle'),
       {

--- a/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
+++ b/packages/react-native/plugin/__tests__/androidProjectBuild.test.ts
@@ -1,10 +1,25 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-import { setMavenRepository } from '../src/withNotifeeProjectGradlePlugin';
+import { setCompileSdkVersion, setMavenRepository } from '../src/withNotifeeProjectGradlePlugin';
 
 describe('[Android] project build.gradle test', () => {
-  it('applies changes to project build.grade', async () => {
+  it('applies maven repository to project build.grade', async () => {
+    let projectGradle = await fs.readFile(
+      path.resolve(__dirname, '../fixtures/project.build.gradle'),
+      {
+        encoding: 'utf-8',
+      },
+    );
+
+    projectGradle = setCompileSdkVersion(projectGradle);
+
+    expect(projectGradle).toContain('compileSdkVersion = 31');
+
+    console.log(projectGradle);
+  });
+
+  it('applies maven repository to project build.grade', async () => {
     let projectGradle = await fs.readFile(
       path.resolve(__dirname, '../fixtures/project.build.gradle'),
       {

--- a/packages/react-native/plugin/__tests__/fullPlugin.test.ts
+++ b/packages/react-native/plugin/__tests__/fullPlugin.test.ts
@@ -1,0 +1,17 @@
+import withNotifee from '../src';
+import { ExpoConfig } from '@expo/config-types';
+
+const dummyConfig: ExpoConfig = {
+  name: 'dummy',
+  slug: 'dummy',
+  _internal: {
+    projectRoot: 'dummy-path',
+  },
+};
+
+describe('Expo plugin', () => {
+  test('should run the plugin without error', () => {
+    const resultConfig = withNotifee(dummyConfig);
+    expect(resultConfig).toMatchSnapshot();
+  });
+});

--- a/packages/react-native/plugin/src/withNotifeeProjectGradlePlugin.ts
+++ b/packages/react-native/plugin/src/withNotifeeProjectGradlePlugin.ts
@@ -10,9 +10,18 @@ const withNotifeeProjectGradlePlugin: ConfigPlugin = config => {
       return { modResults, ...subConfig };
     }
 
+    modResults.contents = setCompileSdkVersion(modResults.contents);
     modResults.contents = setMavenRepository(modResults.contents);
     return { modResults, ...subConfig };
   });
+};
+
+const setCompileSdkVersion = (buildGradle: string): string => {
+  const pattern = /compileSdkVersion = 30/g;
+  if (!buildGradle.match(pattern)) {
+    return buildGradle;
+  }
+  return buildGradle.replace(/compileSdkVersion = 30/, `compileSdkVersion = 31`);
 };
 
 const setMavenRepository = (projectBuildGradle: string): string => {
@@ -25,5 +34,5 @@ const setMavenRepository = (projectBuildGradle: string): string => {
   );
 };
 
-export { setMavenRepository };
+export { setCompileSdkVersion, setMavenRepository };
 export default withNotifeeProjectGradlePlugin;

--- a/tests_react_native/jest.config.js
+++ b/tests_react_native/jest.config.js
@@ -6,12 +6,16 @@ module.exports = {
     '\\.(ts|tsx)$': 'ts-jest',
   },
   rootDir: '..',
-  testMatch: ['<rootDir>/tests_react_native/__tests__/**/*.test.ts'],
+  testMatch: [
+    '<rootDir>/tests_react_native/__tests__/**/*.test.ts',
+    '<rootDir>/packages/react-native/plugin/__tests__/**/*.test.ts',
+  ],
   modulePaths: ['node_modules', '<rootDir>/tests_react_native/node_modules'],
   collectCoverage: true,
 
   collectCoverageFrom: [
     '<rootDir>/packages/react-native/src/**/*.{ts,tsx}',
+    '<rootDir>/packages/react-native/plugin/**/*.{ts,tsx}',
     '!**/node_modules/**',
     '!**/vendor/**',
   ],


### PR DESCRIPTION
## The problem

As mentioned in #314 the current version of Notifee does not build when using expo managed app with the expo plugin as the default `compileSdkVersion` is 30 and Notifee needs 31. Also EAS is using JDK 8 by default and using compileSdkVersion 31 requires the build to be done with JDK 11.

## What is added in this PR
- Expo plugin: Increase compileSdkVersion to 31 in project gradle file if the initial version is 30
- Expo installation documentation: Add a note about the required JDK 11 and the `eas.json` configuration to use JDK 11.

## What's left:
- [x] Run plugins tests and update snapshot
- [x] make an example repository that tests the plugin: https://github.com/abumalick/expo-notifee-example

ref #314