### PR TITLE
fix(android): build.gradle unexpected token

### DIFF
--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -19,7 +19,9 @@ plugins {
 }
 
 if (project.hasProperty('reactNativeProjects')) {
-  reactNativeProjects.each(dependent -> project.evaluationDependsOn(dependent))
+  reactNativeProjects.each { dependent ->
+    project.evaluationDependsOn(dependent)
+  }
 } else {
   project.evaluationDependsOn(':app')
 }


### PR DESCRIPTION
I can't seem to build my react native project using notifee on version `5.2.0`. I'm getting a syntax error/unexpected token it seems. This will fix the issue and gradle builds successfully.

> startup failed:
  build file 'node_modules/@notifee/react-native/android/build.gradle': 22: unexpected token: -> @ line 22, column 38.
       reactNativeProjects.each(dependent -> project.evaluationDependsOn(dependent))