### PR TITLE
chore: remove path-exists to prevent error on install

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -16,7 +16,7 @@
     "prepublishOnly": "cd ../.. && yarn run build:core",
     "format:android": "google-java-format --replace -i $(find . -type f -name \"*.java\")",
     "format:ios": "npm_config_yes=true npx clang-format -i --glob=\"*/**/*.{h,cpp,m,mm}\" --style=Google",
-    "gen-docs": "path-exists ../../docs && typedoc src/index.ts src/types/*.ts src/NotifeeApiModule.ts --out \"../../docs/docs-md\" || echo \"FAILED: gen-docs command only available running package as submodule of notifee.\" "
+    "gen-docs": "typedoc src/index.ts src/types/*.ts src/NotifeeApiModule.ts --out \"../../docs/docs-md\" || echo \"FAILED: gen-docs command only available running package as submodule of notifee.\" "
   },
   "devDependencies": {
     "@expo/config-plugins": "^4.1.0",
@@ -27,7 +27,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "genversion": "^3.0.2",
-    "path-exists-cli": "^2.0.0",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "typedoc": "^0.22.13",


### PR DESCRIPTION
This was causing an error locally to develop the library, fixing to major working (2.0.0) did not work, so removing the dev dep for now