### PR TITLE
fixed TimestampTrigger type

### DIFF
--- a/packages/react-native/src/types/Trigger.ts
+++ b/packages/react-native/src/types/Trigger.ts
@@ -7,7 +7,7 @@ export interface TimestampTrigger {
   /**
    * Constant enum value used to identify the trigger type.
    */
-  type: TriggerType.TIMESTAMP;
+  type: TriggerType;
   /**
    * The timestamp when the notification should first be shown, in milliseconds since 1970.
    */


### PR DESCRIPTION
In this PR:
* Fixed TimestampTrigger type to be the `TriggerType` enum not a member of the enum.
![image](https://user-images.githubusercontent.com/32428883/167112323-c787ec6a-c664-4126-a69b-d69832d19b86.png)
