### PR TITLE
fix: TimestampTrigger type

### DIFF
--- a/packages/react-native/src/types/Trigger.ts
+++ b/packages/react-native/src/types/Trigger.ts
@@ -7,7 +7,7 @@ export interface TimestampTrigger {
   /**
    * Constant enum value used to identify the trigger type.
    */
-  type: TriggerType.TIMESTAMP;
+  type: TriggerType;
   /**
    * The timestamp when the notification should first be shown, in milliseconds since 1970.
    */

--- a/packages/react-native/src/types/Trigger.ts
+++ b/packages/react-native/src/types/Trigger.ts
@@ -8,6 +8,7 @@ export interface TimestampTrigger {
    * Constant enum value used to identify the trigger type.
    */
   type: TriggerType;
+
   /**
    * The timestamp when the notification should first be shown, in milliseconds since 1970.
    */


### PR DESCRIPTION
In this PR:
* Fixed TimestampTrigger type to be the `TriggerType` enum not a member of the enum.

![image](https://user-images.githubusercontent.com/32428883/167113835-1c629b8c-c565-4c43-a6dd-739e0d4c64d4.png)

