### PR TITLE
docs: removed duplicate in cancelNotification API

### DIFF
--- a/packages/react-native/src/types/Module.ts
+++ b/packages/react-native/src/types/Module.ts
@@ -42,7 +42,7 @@ export interface Module {
   /**
    * API used to cancel a single notification.
    *
-   * The `cancelNotification` API removes removes any displayed notifications or ones with triggers
+   * The `cancelNotification` API removes any displayed notifications or ones with triggers
    * set for the specified ID.
    *
    * This method does not cancel [Foreground Service](/react-native/docs/android/foreground-service)


### PR DESCRIPTION
Deleted "removes removes" duplicate in [cancelNotification API](https://notifee.app/react-native/reference/cancelnotification)

The cancelNotification API removes removes any displayed notifications... to The cancelNotification API removes any displayed notifications...

![](https://user-images.githubusercontent.com/43915733/170128961-b7a77998-7ffd-48de-87f9-389d9c076103.png)

Related issue: https://github.com/invertase/notifee/issues/411