### PR TITLE
fix: add `ACCESS_NOTIFICATION_POLICY` android user-permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
   <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" android:maxSdkVersion="30" />
-  <!-- For some devices to enable heads-up notifications as default (https://github.com/invertase/notifee/issues/296) -->
+  <!-- For Xiaomi devices to enable heads-up notifications as default (https://github.com/invertase/notifee/issues/296) -->
   <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
   <application>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
   <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
   <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" android:maxSdkVersion="30" />
+  <!-- For some devices to enable heads-up notifications as default (https://github.com/invertase/notifee/issues/296) -->
+  <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
   <application>
     <!-- Receiver Service -->


### PR DESCRIPTION
For Xiaomi devices,  heads-up notifications are disabled. By adding this permission resolves the issue.
Fixes #296
<img src="https://user-images.githubusercontent.com/14185925/175829796-aed01a17-a499-456e-9842-de257217d8e1.png" width="300" />
