### PR TITLE
docs: Update remote-notification-support.md

### DIFF
--- a/docs-react-native/react-native/docs/ios/remote-notification-support.md
+++ b/docs-react-native/react-native/docs/ios/remote-notification-support.md
@@ -70,7 +70,7 @@ Before, moving to the next step, run the app and check it builds successfully â€
 ## Edit the payload
 Now everything is setup in your app, you can alter your notification payload in two ways:
 
-1. When creating the message contents for sending, in your back-end
+1. Update the message payload, sent via your backend
 2. In a Notification Service Extension in your app when a device receives a remote message
 
 > Make sure that you will set `mutable-content: 1` (mutableContent if you are using firebase admin sdk) when sending notification otherwise Notification Service Extension will NOT be triggered

--- a/docs-react-native/react-native/docs/ios/remote-notification-support.md
+++ b/docs-react-native/react-native/docs/ios/remote-notification-support.md
@@ -78,7 +78,7 @@ Now everything is setup in your app, you can alter your notification payload in 
 > Make sure that you will set `content-available: 1` (contentAvailable if you are using firebase admin sdk) if you want to receive notification when your app is in foreground
 
 
-### 1. When sending from your BE
+### 1. When creating the message contents for sending, in your back-end
 
 ```json
 // FCM
@@ -113,7 +113,7 @@ Now everything is setup in your app, you can alter your notification payload in 
 };
 ```
 
-### 2. In Notification Service Extension
+### 2. In a Notification Service Extension in your app when a device receives a remote message
 
 In your NotifeeNotificationService.m file you should have method `didReceiveNotificationRequest` where we are calling `NotifeeExtensionHelper`. Now you can modify
 `bestAttemptContent` before you send it to `NotifeeExtensionHelper`:

--- a/docs-react-native/react-native/docs/ios/remote-notification-support.md
+++ b/docs-react-native/react-native/docs/ios/remote-notification-support.md
@@ -71,7 +71,7 @@ Before, moving to the next step, run the app and check it builds successfully â€
 Now everything is setup in your app, you can alter your notification payload in two ways:
 
 1. When creating the message contents for sending, in your back-end
-2. In Notification Service Extension when you receive notification
+2. In a Notification Service Extension in your app when a device receives a remote message
 
 > Make sure that you will set `mutable-content: 1` (mutableContent if you are using firebase admin sdk) when sending notification otherwise Notification Service Extension will NOT be triggered
 

--- a/docs-react-native/react-native/docs/ios/remote-notification-support.md
+++ b/docs-react-native/react-native/docs/ios/remote-notification-support.md
@@ -78,7 +78,7 @@ Now everything is setup in your app, you can alter your notification payload in 
 > Make sure that you will set `content-available: 1` (contentAvailable if you are using firebase admin sdk) if you want to receive notification when your app is in foreground
 
 
-### 1. When creating the message contents for sending, in your back-end
+### 1. Update the message payload, sent via your backend
 
 ```json
 // FCM

--- a/docs-react-native/react-native/docs/ios/remote-notification-support.md
+++ b/docs-react-native/react-native/docs/ios/remote-notification-support.md
@@ -70,7 +70,7 @@ Before, moving to the next step, run the app and check it builds successfully â€
 ## Edit the payload
 Now everything is setup in your app, you can alter your notification payload in two ways:
 
-1. When sending from your BE (either via REST api or firebase admin sdk)
+1. When creating the message contents for sending, in your back-end
 2. In Notification Service Extension when you receive notification
 
 > Make sure that you will set `mutable-content: 1` (mutableContent if you are using firebase admin sdk) when sending notification otherwise Notification Service Extension will NOT be triggered


### PR DESCRIPTION
Added warning about mutable-content requirement for NSE to work and also about content-available so the notifications works when app is in foreground.

Also edited section for Edit Payload to include second option on how to edit the payload. Second option is kind of better imho as BE do not need to care too much about FE implementation and it will be easier to switch to other libs - only FE needs to update the code and BE can stay same