### PR TITLE
feat(ios): Add `banner` and `list` options to `IOSForegroundPresentationOptions`

### DIFF
--- a/docs-react-native/react-native/docs/ios/appearance.md
+++ b/docs-react-native/react-native/docs/ios/appearance.md
@@ -67,9 +67,11 @@ await notifee.displayNotification({
   body: 'You are overdue payment on one or more of your accounts!',
   ios: {
     foregroundPresentationOptions: {
-      alert: true,
+      alert: true, // deprecated in iOS 14
       badge: true,
       sound: true,
+      banner: true,
+      list: true,
     },
   },
 });

--- a/docs-react-native/react-native/docs/ios/remote-notification-support.md
+++ b/docs-react-native/react-native/docs/ios/remote-notification-support.md
@@ -90,7 +90,7 @@ Now everything is setup in your app, you can alter your notification payload to 
                 image: 'https://placeimg.com/640/480/any', // URL to pointing to a remote image
                 ios: {
                     sound: 'media/kick.wav', // A local sound file you have inside your app's bundle
-                    foregroundPresentationOptions: {alert true, badge: true, sound: true},
+                    foregroundPresentationOptions: {alert: true, badge: true, sound: true, banner: true, list: true},
                     categoryId: 'post', // A category that's already been created by your app
                     attachments: [{url: 'https://placeimg.com/640/480/any', thumbnailHidden: true}] // array of attachments of type `IOSNotificationAttachment`
                     ... // any other api properties for NotificationIOS

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -93,6 +93,8 @@ struct {
     BOOL alert = [foregroundPresentationOptions[@"alert"] boolValue];
     BOOL badge = [foregroundPresentationOptions[@"badge"] boolValue];
     BOOL sound = [foregroundPresentationOptions[@"sound"] boolValue];
+    BOOL banner = [foregroundPresentationOptions[@"banner"] boolValue];
+    BOOL list = [foregroundPresentationOptions[@"list"] boolValue];
 
     if (badge) {
       presentationOptions |= UNNotificationPresentationOptionBadge;
@@ -104,6 +106,18 @@ struct {
 
     if (alert) {
       presentationOptions |= UNNotificationPresentationOptionAlert;
+    }
+
+    if (banner) {
+      if (@available(iOS 14, *)) {
+        presentationOptions |= UNNotificationPresentationOptionBanner;
+      }
+    }
+
+    if (list) {
+      if (@available(iOS 14, *)) {
+        presentationOptions |= UNNotificationPresentationOptionList;
+      }
     }
 
     NSDictionary *notifeeTrigger = notification.request.content.userInfo[kNotifeeUserInfoTrigger];

--- a/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/ios/foreground_presentation_options.dart
+++ b/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/ios/foreground_presentation_options.dart
@@ -16,20 +16,26 @@
  */
 
 class ForegroundPresentationOptions {
-  ForegroundPresentationOptions({bool? alert, bool? badge, bool? sound})
+  ForegroundPresentationOptions({bool? alert, bool? badge, bool? sound, bool? banner, bool? list})
       : alert = alert ?? false,
         badge = badge ?? false,
         sound = sound ?? false;
+        banner = banner ?? false;
+        list = list ?? false;
 
   bool alert;
   bool badge;
   bool sound;
+  bool banner;
+  bool list;
 
   factory ForegroundPresentationOptions.fromMap(Map<String, dynamic> json) =>
       ForegroundPresentationOptions(
         alert: json['alert'] as bool?,
         badge: json['badge'] as bool?,
         sound: json['sound'] as bool?,
+        banner: json['banner'] as bool?,
+        list: json['list'] as bool?,
       );
 
   Map<String, Object?> asMap() {
@@ -37,6 +43,8 @@ class ForegroundPresentationOptions {
       'alert': alert,
       'badge': badge,
       'sound': sound,
+      'banner': banner,
+      'list': list,
     };
 
     return map;

--- a/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/notification_ios.dart
+++ b/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/notification_ios.dart
@@ -33,7 +33,7 @@ class NotificationIOS {
       this.summaryArgumentCount,
       this.targetContentId}) {
     foregroundPresentationOptions ??=
-        ForegroundPresentationOptions(alert: true, badge: true, sound: true);
+        ForegroundPresentationOptions(alert: true, badge: true, sound: true, banner: true, list: true);
   }
 
   /// Optional array of [IOSNotificationAttachment] interfaces
@@ -98,7 +98,7 @@ class NotificationIOS {
         foregroundPresentationOptions: map['foregroundPresentationOptions'] ==
                 null
             ? ForegroundPresentationOptions(
-                alert: true, badge: true, sound: true)
+                alert: true, badge: true, sound: true, banner: true, list: true)
             : ForegroundPresentationOptions.fromMap(Map<String, dynamic>.from(
                 map['foregroundPresentationOptions'] as Map)),
         categoryId: map['categoryId'] as String?,

--- a/packages/react-native/src/types/NotificationIOS.ts
+++ b/packages/react-native/src/types/NotificationIOS.ts
@@ -125,21 +125,38 @@ export interface IOSForegroundPresentationOptions {
   /**
    * App in foreground dialog box which indicates when a decision has to be made
    *
-   * Defaults to false
+   * Defaults to true
+   * @deprecated Deprecated in iOS 14. Use `banner` and `list` instead
    */
   alert?: boolean;
+
   /**
    * App in foreground notification sound
    *
-   * Defaults to false
+   * Defaults to true
    */
   sound?: boolean;
+
   /**
    * App in foreground badge update
    *
    * Defaults to true
    */
   badge?: boolean;
+
+  /**
+   * Present the notification as a banner
+   *
+   * Defaults to true
+   */
+  banner?: boolean;
+
+  /**
+   * Show the notification in Notification Center
+   *
+   * Defaults to true
+   */
+  list?: boolean;
 }
 
 /**

--- a/packages/react-native/src/validators/validateIOSNotification.ts
+++ b/packages/react-native/src/validators/validateIOSNotification.ts
@@ -27,6 +27,8 @@ export default function validateIOSNotification(ios?: NotificationIOS): Notifica
       alert: true,
       badge: true,
       sound: true,
+      banner: true,
+      list: true,
     },
   };
 
@@ -232,6 +234,36 @@ export default function validateIOSNotification(ios?: NotificationIOS): Notifica
       }
 
       out.foregroundPresentationOptions.badge = ios.foregroundPresentationOptions.badge;
+    }
+
+    if (
+      objectHasProperty<IOSForegroundPresentationOptions>(
+        ios.foregroundPresentationOptions,
+        'banner',
+      )
+    ) {
+      if (!isBoolean(ios.foregroundPresentationOptions.banner)) {
+        throw new Error(
+          "'notification.ios.foregroundPresentationOptions.banner' expected a boolean value.",
+        );
+      }
+
+      out.foregroundPresentationOptions.banner = ios.foregroundPresentationOptions.banner;
+    }
+
+    if (
+      objectHasProperty<IOSForegroundPresentationOptions>(
+        ios.foregroundPresentationOptions,
+        'list',
+      )
+    ) {
+      if (!isBoolean(ios.foregroundPresentationOptions.list)) {
+        throw new Error(
+          "'notification.ios.foregroundPresentationOptions.list' expected a boolean value.",
+        );
+      }
+
+      out.foregroundPresentationOptions.list = ios.foregroundPresentationOptions.list;
     }
   }
 

--- a/tests_react_native/__tests__/validators/validateIOSNotification.test.ts
+++ b/tests_react_native/__tests__/validators/validateIOSNotification.test.ts
@@ -35,7 +35,7 @@ describe('Validate IOS Input', () => {
     test('returns valid when no value is provided', () => {
       const $ = validateIOSNotification();
       expect($).toEqual({
-        foregroundPresentationOptions: { alert: true, badge: true, sound: true },
+        foregroundPresentationOptions: { alert: true, badge: true, sound: true, banner: true, list: true },
       });
     });
 

--- a/tests_react_native/__tests__/validators/validateNotifications.test.ts
+++ b/tests_react_native/__tests__/validators/validateNotifications.test.ts
@@ -73,6 +73,8 @@ describe('Validate Notification', () => {
           alert: true,
           badge: true,
           sound: true,
+          banner: true,
+          list: true,
         },
       });
     });


### PR DESCRIPTION
## Overview

`UNNotificationPresentationOptionAlert` is deprecated in iOS 14 and Apple recommends to use `UNNotificationPresentationOptionList` and `UNNotificationPresentationOptionBanner`.

Thus, I added `list` and `banner` compatibility for iOS.

-----

![Screen Shot 2022-07-16 at 12 47 06 AM](https://user-images.githubusercontent.com/5785300/179345656-7ea392f9-022a-4044-b413-f13e3112a466.png)

## Task List
- [x] Add `banner` and `list` options to `IOSForegroundPresentationOptions`
- [x] Update flutter package
- [x] Update docs

## Reference

* [UNNotificationPresentationOptionAlert | Apple Developer Documentation](https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions/unnotificationpresentationoptionalert)