### PR TITLE
feat(ios): Add iOS 14 compatibility for `alert`

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -105,7 +105,12 @@ struct {
     }
 
     if (alert) {
-      presentationOptions |= UNNotificationPresentationOptionAlert;
+      if (@available(iOS 14, *)) {
+        presentationOptions |=
+            UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner;
+      } else {
+        presentationOptions |= UNNotificationPresentationOptionAlert;
+      }
     }
 
     if (banner) {

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -217,7 +217,7 @@
     // do nothing if trigger is null
     return block(nil);
   }
-  
+
   NSString *identifier = notification[@"id"];
 
   UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier
@@ -267,7 +267,7 @@
   if (notification[@"body"] != nil) {
     content.body = notification[@"body"];
   }
-  
+
   NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
 
   // data

--- a/packages/react-native/src/types/NotificationIOS.ts
+++ b/packages/react-native/src/types/NotificationIOS.ts
@@ -126,7 +126,8 @@ export interface IOSForegroundPresentationOptions {
    * App in foreground dialog box which indicates when a decision has to be made
    *
    * Defaults to true
-   * @deprecated Deprecated in iOS 14. Use `banner` and `list` instead
+   * @(will-be)deprecated Deprecated in iOS 14. Use `banner` and `list` instead.
+   * TODO: Deprecate `alert` when our minimum deployment target becomes iOS 14.
    */
   alert?: boolean;
 


### PR DESCRIPTION
Continuation of #463

ref: https://github.com/invertase/notifee/pull/463#issuecomment-1186612943

----

Added iOS 14 compatibility for `alert` for convenience

```objc
    if (alert) {
      if (@available(iOS 14, *)) {
        presentationOptions |=
            UNNotificationPresentationOptionList | UNNotificationPresentationOptionBanner;
      } else {
        presentationOptions |= UNNotificationPresentationOptionAlert;
      }
    }
```