### PR TITLE
feat: deprecate foregroundPresentationOptions.alert

### DIFF
--- a/docs-react-native/react-native/docs/ios/appearance.md
+++ b/docs-react-native/react-native/docs/ios/appearance.md
@@ -67,7 +67,6 @@ await notifee.displayNotification({
   body: 'You are overdue payment on one or more of your accounts!',
   ios: {
     foregroundPresentationOptions: {
-      alert: true, // deprecated in iOS 14
       badge: true,
       sound: true,
       banner: true,

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -106,26 +106,26 @@ struct {
 
     // if list or banner is true, ignore alert property
     if (banner || list) {
-        if (banner) {
-          if (@available(iOS 14, *)) {
-            presentationOptions |= UNNotificationPresentationOptionBanner;
-          } else {
-              // for iOS 13 we need to set alert
-            presentationOptions |= UNNotificationPresentationOptionAlert;
-          }
+      if (banner) {
+        if (@available(iOS 14, *)) {
+          presentationOptions |= UNNotificationPresentationOptionBanner;
+        } else {
+          // for iOS 13 we need to set alert
+          presentationOptions |= UNNotificationPresentationOptionAlert;
         }
+      }
 
-        if (list) {
-          if (@available(iOS 14, *)) {
-            presentationOptions |= UNNotificationPresentationOptionList;
-          } else {
-              // for iOS 13 we need to set alert
-            presentationOptions |= UNNotificationPresentationOptionAlert;
-          }
+      if (list) {
+        if (@available(iOS 14, *)) {
+          presentationOptions |= UNNotificationPresentationOptionList;
+        } else {
+          // for iOS 13 we need to set alert
+          presentationOptions |= UNNotificationPresentationOptionAlert;
         }
+      }
     } else if (alert) {
-        // TODO: remove alert once it has been fully removed from the notifee API
-        presentationOptions |= UNNotificationPresentationOptionAlert;
+      // TODO: remove alert once it has been fully removed from the notifee API
+      presentationOptions |= UNNotificationPresentationOptionAlert;
     }
 
     NSDictionary *notifeeTrigger = notification.request.content.userInfo[kNotifeeUserInfoTrigger];

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -104,20 +104,28 @@ struct {
       presentationOptions |= UNNotificationPresentationOptionSound;
     }
 
-    if (alert) {
-      presentationOptions |= UNNotificationPresentationOptionAlert;
-    }
+    // if list or banner is true, ignore alert property
+    if (banner || list) {
+        if (banner) {
+          if (@available(iOS 14, *)) {
+            presentationOptions |= UNNotificationPresentationOptionBanner;
+          } else {
+              // for iOS 13 we need to set alert
+            presentationOptions |= UNNotificationPresentationOptionAlert;
+          }
+        }
 
-    if (banner) {
-      if (@available(iOS 14, *)) {
-        presentationOptions |= UNNotificationPresentationOptionBanner;
-      }
-    }
-
-    if (list) {
-      if (@available(iOS 14, *)) {
-        presentationOptions |= UNNotificationPresentationOptionList;
-      }
+        if (list) {
+          if (@available(iOS 14, *)) {
+            presentationOptions |= UNNotificationPresentationOptionList;
+          } else {
+              // for iOS 13 we need to set alert
+            presentationOptions |= UNNotificationPresentationOptionAlert;
+          }
+        }
+    } else if (alert) {
+        // TODO: remove alert once it has been fully removed from the notifee API
+        presentationOptions |= UNNotificationPresentationOptionAlert;
     }
 
     NSDictionary *notifeeTrigger = notification.request.content.userInfo[kNotifeeUserInfoTrigger];

--- a/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/notification_ios.dart
+++ b/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/notification_ios.dart
@@ -32,8 +32,7 @@ class NotificationIOS {
       this.summaryArgument,
       this.summaryArgumentCount,
       this.targetContentId}) {
-    foregroundPresentationOptions ??= ForegroundPresentationOptions(
-        alert: true, badge: true, sound: true, banner: true, list: true);
+    foregroundPresentationOptions ??= ForegroundPresentationOptions(badge: true, sound: true, banner: true, list: true);
   }
 
   /// Optional array of [IOSNotificationAttachment] interfaces
@@ -97,8 +96,7 @@ class NotificationIOS {
         badgeCount: map['badgeCount'] as int?,
         foregroundPresentationOptions: map['foregroundPresentationOptions'] ==
                 null
-            ? ForegroundPresentationOptions(
-                alert: true, badge: true, sound: true, banner: true, list: true)
+            ? ForegroundPresentationOptions(badge: true, sound: true, banner: true, list: true)
             : ForegroundPresentationOptions.fromMap(Map<String, dynamic>.from(
                 map['foregroundPresentationOptions'] as Map)),
         categoryId: map['categoryId'] as String?,

--- a/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/notification_ios.dart
+++ b/packages/flutter/packages/notifee_platform_interface/lib/src/models/notification/notification_ios.dart
@@ -32,7 +32,8 @@ class NotificationIOS {
       this.summaryArgument,
       this.summaryArgumentCount,
       this.targetContentId}) {
-    foregroundPresentationOptions ??= ForegroundPresentationOptions(badge: true, sound: true, banner: true, list: true);
+    foregroundPresentationOptions ??= ForegroundPresentationOptions(
+        badge: true, sound: true, banner: true, list: true);
   }
 
   /// Optional array of [IOSNotificationAttachment] interfaces
@@ -96,7 +97,8 @@ class NotificationIOS {
         badgeCount: map['badgeCount'] as int?,
         foregroundPresentationOptions: map['foregroundPresentationOptions'] ==
                 null
-            ? ForegroundPresentationOptions(badge: true, sound: true, banner: true, list: true)
+            ? ForegroundPresentationOptions(
+                badge: true, sound: true, banner: true, list: true)
             : ForegroundPresentationOptions.fromMap(Map<String, dynamic>.from(
                 map['foregroundPresentationOptions'] as Map)),
         categoryId: map['categoryId'] as String?,

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -103,7 +103,7 @@ To utilise Detox's functionality to mock a local notification and trigger notife
     __notifee_notification: {
       ios: {
         foregroundPresentationOptions: {
-          alert: true,
+          banner: true,
         },
       },
       data: {}

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -104,6 +104,7 @@ To utilise Detox's functionality to mock a local notification and trigger notife
       ios: {
         foregroundPresentationOptions: {
           banner: true,
+          list: true,
         },
       },
       data: {}

--- a/packages/react-native/src/types/NotificationIOS.ts
+++ b/packages/react-native/src/types/NotificationIOS.ts
@@ -126,7 +126,7 @@ export interface IOSForegroundPresentationOptions {
    * App in foreground dialog box which indicates when a decision has to be made
    *
    * Defaults to true
-   * @deprecated Deprecated in iOS 14. Use `banner` and `list` instead
+   * @deprecated Use `banner` and `list` instead
    */
   alert?: boolean;
 
@@ -147,12 +147,16 @@ export interface IOSForegroundPresentationOptions {
   /**
    * Present the notification as a banner
    *
+   * For iOS 13 and lower, will be equivalent to setting `alert` to true
+   *
    * Defaults to true
    */
   banner?: boolean;
 
   /**
    * Show the notification in Notification Center
+   *
+   * For iOS 13 and lower, will be equivalent to setting `alert` to true
    *
    * Defaults to true
    */

--- a/packages/react-native/src/validators/validateIOSNotification.ts
+++ b/packages/react-native/src/validators/validateIOSNotification.ts
@@ -24,7 +24,6 @@ export default function validateIOSNotification(ios?: NotificationIOS): Notifica
     foregroundPresentationOptions: IOSForegroundPresentationOptions;
   } = {
     foregroundPresentationOptions: {
-      alert: true,
       badge: true,
       sound: true,
       banner: true,

--- a/packages/react-native/src/validators/validateIOSNotification.ts
+++ b/packages/react-native/src/validators/validateIOSNotification.ts
@@ -24,6 +24,7 @@ export default function validateIOSNotification(ios?: NotificationIOS): Notifica
     foregroundPresentationOptions: IOSForegroundPresentationOptions;
   } = {
     foregroundPresentationOptions: {
+      alert: true,
       badge: true,
       sound: true,
       banner: true,


### PR DESCRIPTION
See discussions on https://github.com/invertase/notifee/pull/465
Deprecates .alert from foregroundPresentationOptions
Should not have any breaking changes
- Users should remove .alert from their payload and use .list and .banner instead if they are setting custom foregroundPresentationOptions
- Users can still use .alert, it is only deprecated