### PR TITLE
docs(triggers): add information on maximum timestamp counts

### DIFF
--- a/docs-react-native/react-native/docs/triggers.md
+++ b/docs-react-native/react-native/docs/triggers.md
@@ -147,6 +147,13 @@ const trigger: TimestampTrigger = {
 };
 ```
 
+### Maximum TimestampTrigger Count
+
+Android has a system limit of 50 timestamp triggers active at one time.
+iOS appears to have a limit of [64 timestamp triggers active at one time](https://developer.apple.com/forums/thread/23288), but it is not in [the official documentation](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649508-add).
+
+### iOS Initial Trigger Limitations
+
 Please note, for iOS, a repeating trigger does not work the same as Android - the initial trigger cannot be delayed:
 
 - `HOURLY`: the starting date and hour will be ignored, and only the minutes and seconds will be taken into the account. If the timestamp is set to trigger in 3 hours and repeat every 5th minute of the hour, the alert will not fire in 3 hours, but will instead fire immediately on the next 5th minute of the hour.


### PR DESCRIPTION

I'm not sure on the Android 50 timestamp trigger count limit though, on stackoverflow I only see limits of 500 and only on Samsung devices.

What's the source / experience on 50 as the limit so we can link it?

https://stackoverflow.com/questions/29344971/java-lang-securityexception-too-many-alarms-500-registered-from-pid-10790-u?noredirect=1&lq=1

This is cribbed from here - it comes up a lot, seems it should be in the docs: https://github.com/invertase/notifee/issues/488#issuecomment-1211849875