### PR TITLE
Correct names (according to TypeScript)

### DIFF
--- a/docs-react-native/react-native/docs/android/interaction.md
+++ b/docs-react-native/react-native/docs/android/interaction.md
@@ -335,8 +335,8 @@ If the user has provided custom input via free text or choices, we're able to gr
 import notifee, { EventType } from '@notifee/react-native';
 
 notifee.onBackgroundEvent(async ({ type, detail }) => {
-  if (type === EventType.ACTION_PRESS && detail.action.id === 'reply') {
-    await updateChat(detail.notification.data.chatId, detail.action.input);
+  if (type === EventType.ACTION_PRESS && detail.pressAction.id === 'reply') {
+    await updateChat(detail.notification.data.chatId, detail.input);
     await notifee.cancelNotification(detail.notification.id);
   }
 });


### PR DESCRIPTION
Corrected the parameter names on the "detail" parameter - detail.action does not exist, thus nor does detail.action.input

I'm not sure if these were just copy-paste issues or what, because the code example for the foreground handler is correct. It was just in this background handler I was running into type errors.