### PR TITLE
fix: validate category action input ts errors

### DIFF
--- a/packages/react-native/src/validators/validateAndroidAction.ts
+++ b/packages/react-native/src/validators/validateAndroidAction.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2016-present Invertase Limited
  */
 
-import { objectHasProperty, isBoolean, isObject, isString, isUndefined } from '../utils';
+import { objectHasProperty, isObject, isString, isUndefined } from '../utils';
 
 import { AndroidAction } from '../types/NotificationAndroid';
 import validateAndroidPressAction from './validateAndroidPressAction';
@@ -39,7 +39,7 @@ export default function validateAndroidAction(action: AndroidAction): AndroidAct
   }
 
   if (objectHasProperty(action, 'input') && !isUndefined(action.input)) {
-    if (isBoolean(action.input) && action.input) {
+    if (action.input === true) {
       out.input = validateAndroidInput();
     } else {
       try {

--- a/packages/react-native/src/validators/validateIOSCategoryAction.ts
+++ b/packages/react-native/src/validators/validateIOSCategoryAction.ts
@@ -26,7 +26,7 @@ export default function validateIOSCategoryAction(
   };
 
   if (objectHasProperty(action, 'input') && !isUndefined(action.input)) {
-    if (isBoolean(action.input) && action.input) {
+    if (action.input === true) {
       out.input = true;
     } else {
       try {


### PR DESCRIPTION
Hello!

Currently, we're getting warnings in our project, due to: 
- `validateAndroidAction` getting type `true | AndroidInput` instead of `AndroidInput`
- `validateIOSCategoryAction` getting type `true | IOSInput` instead of `IOSInput`

I've simplified code to make it check if `action.input` strictly equals to `true`, instead of checking if it's boolean and if it's truthy.

This seems more robust and easily readable, plus it's not complaining anymore.

Comments welcome, as again, I might be in the wrong here :) 