### PR TITLE
chore: bump version of android dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,7 +110,7 @@ dependencies {
   api 'androidx.work:work-runtime:2.7.1' // https://developer.android.com/jetpack/androidx/releases/work
   api 'com.facebook.fresco:fresco:2.6.0' // https://github.com/facebook/fresco/releases
 
-  def room_version = '2.3.0' // https://developer.android.com/jetpack/androidx/releases/room
+  def room_version = '2.4.3' // https://developer.android.com/jetpack/androidx/releases/room
   implementation "androidx.room:room-runtime:$room_version"
   annotationProcessor "androidx.room:room-compiler:$room_version"
 


### PR DESCRIPTION
There's an issue with Apple Silicon and this older version of room, newer version fixes this issue.

Also, there's a bunch of fixes with the current stable version.

Error log before fix:

```
Caused by: java.lang.Exception: No native library is found for os.name=Mac and os.arch=aarch64. path=/org/sqlite/native/Mac/aarch64
	at org.sqlite.SQLiteJDBCLoader.loadSQLiteNativeLibrary(SQLiteJDBCLoader.java:333)
	at org.sqlite.SQLiteJDBCLoader.initialize(SQLiteJDBCLoader.java:64)
	at androidx.room.verifier.DatabaseVerifier.<clinit>(DatabaseVerifier.kt:71)
```