### PR TITLE
docs(android): Information about specifying compileSdkVersion & targetSdkVersion

### DIFF
--- a/docs-react-native/react-native/docs/installation.md
+++ b/docs-react-native/react-native/docs/installation.md
@@ -18,8 +18,20 @@ npm install --save @notifee/react-native
 yarn add @notifee/react-native
 ```
 
+## 2. Configuration Changes
+The values of the compileSdkVersion & targetSdkVersion might need to be chnaged. compileSdkVersion needs to be at least 33. In addition, if your app is going to request permission on Android 13 via requestPermission, targetSdkVersion needs to be at least 33, as well. These setting are in the file `/android/build.gradle`. 
+```gradle
+buildscript {
+  ext {
+    compileSdkVersion = 33 // at least 33
+    targetSdkVersion = 33 // If requesting permission on Android 13 via requestPermission, at least 33 
+    ... 
+ } 
+ ... 
+}
+```
 
-## 2. Autolinking with React Native
+## 3. Autolinking with React Native
 Users on React Native 0.60+ automatically have access to "[autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md)",
 requiring no further manual installation steps. To automatically link the package, rebuild your project:
 


### PR DESCRIPTION
Added information about specifying compileSdkVersion & targetSdkVersion to the installation instructions. 