### PR TITLE
fix: Add keys to `remote` type

### DIFF
--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -74,7 +74,12 @@ export interface Notification {
    *
    * @platform ios
    */
-  readonly remote?: boolean;
+  readonly remote?: {
+    messageId: string;
+    senderId: string;
+    mutableContent?: number;
+    contentAvailable?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
Change from `boolean` to include the keys added here: https://github.com/invertase/notifee/blob/main/ios/NotifeeCore/NotifeeCoreUtil.m#L589-L599