### PR TITLE
fix(android): fix an issue when requesting permissions for Android 12 or lower

### DIFF
--- a/android/src/main/java/app/notifee/core/Notifee.java
+++ b/android/src/main/java/app/notifee/core/Notifee.java
@@ -46,8 +46,7 @@ public class Notifee {
   private static Notifee mNotifee = null;
   private static NotifeeConfig mNotifeeConfig = null;
 
-  @KeepForSdk
-  public static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 11111;
+  @KeepForSdk public static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 11111;
 
   @KeepForSdk
   public static Notifee getInstance() {
@@ -429,11 +428,7 @@ public class Notifee {
 
   @KeepForSdk
   public void setRequestPermissionCallback(MethodCallResult<Bundle> result) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      requestPermissionCallResult = result;
-    } else {
-      getNotificationSettings(result);
-    }
+    requestPermissionCallResult = result;
   }
 
   @KeepForSdk


### PR DESCRIPTION
Closes #555

- Fixes an issue where sometimes the permissions activity is null when requesting permissions on Android, which appears to only be an issue for Android 11 and below. 
- As a precaution, we will return notification settings for devices 12 or lower, in addition to checking if the activity is null before calling requestPermissions.
- Also added more code comments and logger messages