### PR TITLE
fix(expo): bump compileSdkVersion for expo plugin to 33

### DIFF
--- a/packages/react-native/plugin/src/withNotifeeProjectGradlePlugin.ts
+++ b/packages/react-native/plugin/src/withNotifeeProjectGradlePlugin.ts
@@ -20,7 +20,7 @@ const setCompileSdkVersion = (buildGradle: string): string => {
   if (!buildGradle.match(pattern)) {
     return buildGradle;
   }
-  return buildGradle.replace(/compileSdkVersion = 30/, `compileSdkVersion = 31`);
+  return buildGradle.replace(/compileSdkVersion = 30/, `compileSdkVersion = 33`);
 };
 
 export { setCompileSdkVersion };


### PR DESCRIPTION
Bumps compileSdkVersion from 31 to 33 for expo plugin

Closes #564

Related https://github.com/expo/expo/issues/19385