### PR TITLE
fix: isAppInForeground

### DIFF
--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
@@ -210,12 +210,9 @@ class NotifeeReactUtils {
     for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
       if (appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
           && appProcess.processName.equals(packageName)) {
-        ReactContext reactContext;
-
-        try {
-          reactContext = (ReactContext) context;
-        } catch (ClassCastException exception) {
-          return true;
+        ReactContext reactContext = getReactContext();
+        if (reactContext == null) {
+          return false;
         }
 
         return reactContext.getLifecycleState() == LifecycleState.RESUMED;

--- a/tests_react_native/example/notifications.ts
+++ b/tests_react_native/example/notifications.ts
@@ -4,8 +4,8 @@ import {
   AndroidLaunchActivityFlag,
   AndroidCategory,
   AndroidImportance,
+  AndroidFlags,
 } from '@notifee/react-native';
-import { AndroidFlags } from '@notifee/react-native/src';
 
 export const notifications: { key: string; notification: Notification | Notification[] }[] = [
   {

--- a/tests_react_native/index.test.js
+++ b/tests_react_native/index.test.js
@@ -15,6 +15,7 @@ function TestApp() {
       specs={[NotificationSpec, ApiSpec]}
       store={testHookStore}
       customReporter={NativeReporter.reporter}
+      only={['focus']}
     >
       <App />
     </Tester>

--- a/tests_react_native/index.test.js
+++ b/tests_react_native/index.test.js
@@ -15,7 +15,6 @@ function TestApp() {
       specs={[NotificationSpec, ApiSpec]}
       store={testHookStore}
       customReporter={NativeReporter.reporter}
-      only={['focus']}
     >
       <App />
     </Tester>

--- a/tests_react_native/specs/notification.spec.ts
+++ b/tests_react_native/specs/notification.spec.ts
@@ -280,12 +280,12 @@ export function NotificationSpec(spec: TestScope): void {
 
         // Manual steps:
         // 1. Minimize app
-        // 2. Open notification drawer
+        // 2. Open notifications
         // 3. Tap on 'First Action'
         // 4. Make sure you see:
         // >  WARN  Received a ACTION_PRESS Background event in JS mode.
         // >  WARN  Notification Cancelled first_action
-      });
+      }, 'focus');
     });
   });
 

--- a/tests_react_native/specs/notification.spec.ts
+++ b/tests_react_native/specs/notification.spec.ts
@@ -250,6 +250,42 @@ export function NotificationSpec(spec: TestScope): void {
           });
         },
       );
+
+      spec.it('displays a notification with a quick action without input', async function () {
+        return new Promise(async (resolve, reject) => {
+          return notifee
+            .displayNotification({
+              title: '',
+              body: '',
+              android: {
+                channelId: 'high',
+                actions: [
+                  {
+                    title: 'First Action',
+                    pressAction: {
+                      id: 'first_action',
+                    },
+                  },
+                ],
+              },
+            })
+            .then(id => {
+              expect(id).equals(id);
+              resolve();
+            })
+            .catch(e => {
+              reject(e);
+            });
+        });
+
+        // Manual steps:
+        // 1. Minimize app
+        // 2. Open notification drawer
+        // 3. Tap on 'First Action'
+        // 4. Make sure you see:
+        // >  WARN  Received a ACTION_PRESS Background event in JS mode.
+        // >  WARN  Notification Cancelled first_action
+      });
     });
   });
 

--- a/tests_react_native/specs/notification.spec.ts
+++ b/tests_react_native/specs/notification.spec.ts
@@ -280,12 +280,12 @@ export function NotificationSpec(spec: TestScope): void {
 
         // Manual steps:
         // 1. Minimize app
-        // 2. Open notifications
+        // 2. Open notification drawer
         // 3. Tap on 'First Action'
         // 4. Make sure you see:
         // >  WARN  Received a ACTION_PRESS Background event in JS mode.
         // >  WARN  Notification Cancelled first_action
-      }, 'focus');
+      });
     });
   });
 


### PR DESCRIPTION
This PR fixes two issues:
1. Issue with registering in `test_react_native/example`.
Because `AndroidFlags` was imported with `'@notifee/react-native/src'` and everything else was imported `'@notifee/react-native'` it caused double initialization of NotifeeApiModule which caused the following errors showing when `yarn tests_rn:android:test` is run:
```
WARN  registerHeadlessTask or registerCancellableHeadlessTask called multiple times for same key 'app.notifee.foreground-service-headless-task'
WARN  registerHeadlessTask or registerCancellableHeadlessTask called multiple times for same key 'app.notifee.notification-event'
WARN  [notifee] no background event handler has been set. Set a handler via the "onBackgroundEvent" method.
```

2. Issue with Quick Action tap not being handled on Android 12 because of bug in ` isAppInForeground`.
The issue started to show in Android 12 because that version Android for some reason considers `IMPORTANCE_FOREGROUND` for importance of the running app even if app is minimized.

Closes https://github.com/invertase/notifee/issues/404
