### PR TITLE
fix(android): set initial notification for quick actions

### DIFF
--- a/android/src/main/java/app/notifee/core/NotificationReceiverHandler.java
+++ b/android/src/main/java/app/notifee/core/NotificationReceiverHandler.java
@@ -94,6 +94,10 @@ public class NotificationReceiverHandler {
     NotificationManagerCompat.from(context)
         .cancel(intent.getIntExtra(NOTIFICATION_ID_INTENT_KEY, 0));
 
+    InitialNotificationEvent initialNotificationEvent =
+        new InitialNotificationEvent(notificationModel, extras);
+    EventBus.postSticky(initialNotificationEvent);
+
     // Send event
     EventBus.post(new NotificationEvent(TYPE_ACTION_PRESS, notificationModel, extras));
   }


### PR DESCRIPTION
Hi, I have noticed I don't get any press actions on the initial notification event, after some debugging with LogCat I found handleNotificationPressIntent doesn't have InitialNotificationEvent.

tested version "@notifee/react-native": "^7.1.0"

https://github.com/invertase/notifee/issues/546