### PR TITLE
ci(stale): add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+---
+name: Mark stale issues and pull requests
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 35 * * * *
+permissions:
+  contents: read
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          operations-per-run: 1000
+          stale-issue-message: |
+            Hello 👋, to help manage issues we automatically close stale issues.
+
+            This issue has been automatically marked as stale because it has not had activity for quite some time.Has this issue been fixed, or does it still require attention?
+
+            > This issue will be closed in 15 days if no further activity occurs.
+
+            Thank you for your contributions.
+          stale-pr-message: |
+            Hello 👋, this PR has been opened for more than 2 months with no activity on it.
+
+            If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing!
+
+            You have 15 days until this gets closed automatically
+          exempt-issue-labels: '📌%20pin,Help:%20Good%20First%20Issue,Blocked:%20Needs%20Review'
+          exempt-pr-labels: '📌%20pin,Help:%20Good First%20Issue,Blocked:%20Needs%20Review'
+          close-issue-reason: not_planned
+          days-before-stale: 28
+          days-before-close: 15
+          stale-issue-label: 'Type: Stale'


### PR DESCRIPTION

Noticed previous stale bot was simply not performing in react-native-firebase, and scanned around for other related repos that needed an update

Turns out this repo does not even have a stale bot, but it really should as we do rely on community contributions so much here

So here's a config that works for react-native-firebase (verbatim, no changes)

Note that labels may need a change (or...perhaps best to update them?)

- add 'Type: Stale' for the bot
- add '📌 pin' as a keep open
- add 'Blocked: Needs Review' as a keep open
- add 'Help: Good First Issue' as a keep open