### PR TITLE
fix: android 11 close notificaiton drawer for quick actions

### DIFF
--- a/android/src/main/java/app/notifee/core/ReceiverService.java
+++ b/android/src/main/java/app/notifee/core/ReceiverService.java
@@ -211,10 +211,10 @@ public class ReceiverService extends Service {
       int targetSdkVersion =
           ContextHolder.getApplicationContext().getApplicationInfo().targetSdkVersion;
 
-      // Close notification drawer if targetSdkVersion is Android 11 and lower
+      // Close notification drawer if application SDK is Android 11 and lower
       // See
       // https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
-      if (targetSdkVersion < Build.VERSION_CODES.S) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
         ContextHolder.getApplicationContext()
             .sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
       }


### PR DESCRIPTION
Closes #579

Despite what android docs say, we should check for the application sdk version and not the target sdk version when determining if the notification drawer should be closed