### PR TITLE
feat(android): add TYPE_FG_ALREADY_EXIST event type

### DIFF
--- a/android/src/main/java/app/notifee/core/ForegroundService.java
+++ b/android/src/main/java/app/notifee/core/ForegroundService.java
@@ -19,7 +19,6 @@ package app.notifee.core;
 
 import android.app.Notification;
 import android.app.Service;
-import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;

--- a/android/src/main/java/app/notifee/core/ForegroundService.java
+++ b/android/src/main/java/app/notifee/core/ForegroundService.java
@@ -19,6 +19,7 @@ package app.notifee.core;
 
 import android.app.Notification;
 import android.app.Service;
+import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -38,7 +39,7 @@ public class ForegroundService extends Service {
 
   public static String mCurrentNotificationId = null;
 
-  static void start(int hashCode, Notification notification, Bundle notificationBundle) {
+  static ComponentName start(int hashCode, Notification notification, Bundle notificationBundle) {
     Intent intent = new Intent(ContextHolder.getApplicationContext(), ForegroundService.class);
     intent.setAction(START_FOREGROUND_SERVICE_ACTION);
     intent.putExtra("hashCode", hashCode);
@@ -46,10 +47,10 @@ public class ForegroundService extends Service {
     intent.putExtra("notificationBundle", notificationBundle);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      ContextHolder.getApplicationContext().startForegroundService(intent);
+      return ContextHolder.getApplicationContext().startForegroundService(intent);
     } else {
       // TODO test this on older device
-      ContextHolder.getApplicationContext().startService(intent);
+      return ContextHolder.getApplicationContext().startService(intent);
     }
   }
 

--- a/android/src/main/java/app/notifee/core/ForegroundService.java
+++ b/android/src/main/java/app/notifee/core/ForegroundService.java
@@ -27,6 +27,7 @@ import android.os.IBinder;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationManagerCompat;
 import app.notifee.core.event.ForegroundServiceEvent;
+import app.notifee.core.event.NotificationEvent;
 import app.notifee.core.interfaces.MethodCallResult;
 import app.notifee.core.model.NotificationModel;
 
@@ -39,7 +40,7 @@ public class ForegroundService extends Service {
 
   public static String mCurrentNotificationId = null;
 
-  static ComponentName start(int hashCode, Notification notification, Bundle notificationBundle) {
+  static void start(int hashCode, Notification notification, Bundle notificationBundle) {
     Intent intent = new Intent(ContextHolder.getApplicationContext(), ForegroundService.class);
     intent.setAction(START_FOREGROUND_SERVICE_ACTION);
     intent.putExtra("hashCode", hashCode);
@@ -47,10 +48,10 @@ public class ForegroundService extends Service {
     intent.putExtra("notificationBundle", notificationBundle);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      return ContextHolder.getApplicationContext().startForegroundService(intent);
+      ContextHolder.getApplicationContext().startForegroundService(intent);
     } else {
       // TODO test this on older device
-      return ContextHolder.getApplicationContext().startService(intent);
+      ContextHolder.getApplicationContext().startService(intent);
     }
   }
 
@@ -107,6 +108,9 @@ public class ForegroundService extends Service {
         } else if (mCurrentNotificationId.equals(notificationModel.getId())) {
           NotificationManagerCompat.from(ContextHolder.getApplicationContext())
               .notify(hashCode, notification);
+        } else {
+          EventBus.post(
+            new NotificationEvent(NotificationEvent.TYPE_FG_ALREADY_EXIST, notificationModel));
         }
       }
     }

--- a/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -579,11 +579,7 @@ class NotificationManager {
               }
 
               if (androidBundle.getAsForegroundService()) {
-                if(ForegroundService.start(hashCode, notification, notificationModel.toBundle()) != null) {
-                  EventBus.post(
-                    new NotificationEvent(NotificationEvent.TYPE_FG_ALREADY_EXIST, notificationModel));
-                  return null;
-                }
+                ForegroundService.start(hashCode, notification, notificationModel.toBundle());
               } else {
                 NotificationManagerCompat.from(getApplicationContext())
                     .notify(androidBundle.getTag(), hashCode, notification);

--- a/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -579,7 +579,11 @@ class NotificationManager {
               }
 
               if (androidBundle.getAsForegroundService()) {
-                ForegroundService.start(hashCode, notification, notificationModel.toBundle());
+                if(ForegroundService.start(hashCode, notification, notificationModel.toBundle()) != null) {
+                  EventBus.post(
+                    new NotificationEvent(NotificationEvent.TYPE_FG_ALREADY_EXIST, notificationModel));
+                  return null;
+                }
               } else {
                 NotificationManagerCompat.from(getApplicationContext())
                     .notify(androidBundle.getTag(), hashCode, notification);

--- a/android/src/main/java/app/notifee/core/event/NotificationEvent.java
+++ b/android/src/main/java/app/notifee/core/event/NotificationEvent.java
@@ -37,6 +37,8 @@ public class NotificationEvent {
 
   @KeepForSdk public static final int TYPE_TRIGGER_NOTIFICATION_CREATED = 7;
 
+  @KeepForSdk public static final int TYPE_FG_ALREADY_EXIST = 8;
+
   private final int type;
   private final Bundle extras;
   private final NotificationModel notification;

--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -373,7 +373,7 @@ export enum EventType {
 
   /**
    * **ANDROID ONLY**
-   * 
+   *
    * Event type is sent when a notification wants to start a foreground service but a foreground service is already started.
    */
   FG_ALREADY_EXIST = 8,

--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -370,6 +370,13 @@ export enum EventType {
    * Event type is sent when a notification trigger is created.
    */
   TRIGGER_NOTIFICATION_CREATED = 7,
+
+  /**
+   * **ANDROID ONLY**
+   * 
+   * Event type is sent when a notification wants to start a foreground service but a foreground service is already started.
+   */
+  FG_ALREADY_EXIST = 8,
 }
 
 /**
@@ -388,6 +395,7 @@ export interface EventDetail {
    *  - [`EventType.ACTION_PRESS`](/react-native/reference/eventtype#action_press)
    *  - [`EventType.DELIVERED`](/react-native/reference/eventtype#delivered)
    *  - [`EventType.TRIGGER_NOTIFICATION_CREATED`](/react-native/reference/eventtype#trigger_notification_created)
+   *  - [`EventType.FG_ALREADY_EXIST`](/react-native/reference/eventtype#fg_already_exist)
    */
   notification?: Notification;
 


### PR DESCRIPTION
closes #631 and #630

this adds a new event type for android, which will be sent if android tries to push a notification as foreground service, but a foreground service already exist

this allows to detect and show a different notification when a foreground service is active and a new one cannot be started

I did not know how to add this to the docs (didn't find a markdown file, so I guess it's auto generated ?)