### PR TITLE
fix: parsing lights for trigger notifications with colors as strings

### DIFF
--- a/android/src/main/java/app/notifee/core/model/NotificationAndroidModel.java
+++ b/android/src/main/java/app/notifee/core/model/NotificationAndroidModel.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 
 @Keep
 public class NotificationAndroidModel {
+  private static final String TAG = "NotificationAndroidModel";
   private Bundle mNotificationAndroidBundle;
 
   private NotificationAndroidModel(Bundle bundle) {
@@ -285,16 +286,23 @@ public class NotificationAndroidModel {
    */
   public @Nullable ArrayList<Integer> getLights() {
     if (mNotificationAndroidBundle.containsKey("lights")) {
-      ArrayList<?> lightList =
-          Objects.requireNonNull(mNotificationAndroidBundle.getIntegerArrayList("lights"));
-      String rawColor = (String) lightList.get(0);
+      try {
+        ArrayList<?> lightList =
+          Objects.requireNonNull(mNotificationAndroidBundle.getParcelableArrayList("lights"));
+        String rawColor = (String) lightList.get(0);
 
-      ArrayList<Integer> lights = new ArrayList<>(3);
-      lights.add(Color.parseColor(rawColor));
-      lights.add((Integer) lightList.get(1));
-      lights.add((Integer) lightList.get(2));
+        ArrayList<Integer> lights = new ArrayList<>(3);
+        lights.add(Color.parseColor(rawColor));
+        lights.add((Integer) lightList.get(1));
+        lights.add((Integer) lightList.get(2));
 
-      return lights;
+        return lights;
+      } catch (Exception e) {
+        Logger.e(
+          TAG,
+          "getLights -> Failed to parse lights");
+        return null;
+      }
     }
 
     return null;

--- a/tests_react_native/example/notifications.ts
+++ b/tests_react_native/example/notifications.ts
@@ -5,6 +5,7 @@ import {
   AndroidCategory,
   AndroidImportance,
   AndroidFlags,
+  AndroidColor,
 } from '@notifee/react-native';
 
 export const notifications: { key: string; notification: Notification | Notification[] }[] = [
@@ -49,6 +50,7 @@ export const notifications: { key: string; notification: Notification | Notifica
         pressAction: {
           id: 'default',
         },
+        lights: [AndroidColor.PURPLE, 300, 600],
       },
       ios: {},
     },


### PR DESCRIPTION
Closes #618. From debugging, a null exception was thrown when a trigger notification was being processed with a lights array, and when that lights array contains a string value for a color (e.g. 'purple'). 

The notification however is displayed correctly via `displayNotification`.

The original issue described it was an Android 13 thing which it quite possibly be.

Either way, whether the notification is displayed via `notifee.displayNotification` or `notifee.createTriggerNotification`, fundamentally the code was wrong as the lights array can include strings as well as integers.  First one being a string, second and third being a number. 

Also, for additional safety, added a try/catch.