### PR TITLE
fix(android): auto cancel with actions

### DIFF
--- a/android/src/main/java/app/notifee/core/NotificationReceiverHandler.java
+++ b/android/src/main/java/app/notifee/core/NotificationReceiverHandler.java
@@ -91,8 +91,10 @@ public class NotificationReceiverHandler {
       }
     }
 
-    NotificationManagerCompat.from(context)
+    if (notificationModel.getAndroid().getAutoCancel()) {
+      NotificationManagerCompat.from(context)
         .cancel(intent.getIntExtra(NOTIFICATION_ID_INTENT_KEY, 0));
+    }
 
     InitialNotificationEvent initialNotificationEvent =
         new InitialNotificationEvent(notificationModel, extras);

--- a/tests_react_native/example/notifications.ts
+++ b/tests_react_native/example/notifications.ts
@@ -159,7 +159,27 @@ export const notifications: { key: string; notification: Notification | Notifica
       },
     },
   },
-
+  {
+    key: 'Ongoing with Press',
+    notification: {
+      title: 'Ongoing with Press',
+      body: 'Notification with actions',
+      ios: {
+        categoryId: 'actions',
+      },
+      android: {
+        pressAction: { id: 'default', launchActivity: 'default' },
+        actions: [
+          {
+            pressAction: { id: 'an-action-id' },
+            title: 'An Action',
+          },
+        ],
+        autoCancel: false,
+        ongoing: true,
+      },
+    },
+  },
   {
     key: 'Actions (event only)',
     notification: {


### PR DESCRIPTION
Fixes an issue where if autoCancel is set to `false`, for android actions this is ignored and we are in fact canceling the notification once the action is handled.

We have this behaviour for android 11 and below, but it was missing for android 12 and above.

Fixes #697