### PR TITLE
fix(android): prevent interval triggers from firing immediately

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,10 +106,10 @@ dependencies {
   api 'androidx.annotation:annotation:1.3.0' // https://developer.android.com/jetpack/androidx/releases/annotation
   api 'androidx.concurrent:concurrent-futures:1.1.0' // https://developer.android.com/jetpack/androidx/releases/concurrent
   api 'com.google.android.gms:play-services-tasks:18.0.1' // https://developers.google.com/android/guides/releases
-  api 'androidx.work:work-runtime:2.7.1' // https://developer.android.com/jetpack/androidx/releases/work
+  api 'androidx.work:work-runtime:2.8.0' // https://developer.android.com/jetpack/androidx/releases/work
   api 'com.facebook.fresco:fresco:2.6.0' // https://github.com/facebook/fresco/releases
 
-  def room_version = '2.4.3' // https://developer.android.com/jetpack/androidx/releases/room
+  def room_version = '2.5.0' // https://developer.android.com/jetpack/androidx/releases/room
   implementation "androidx.room:room-runtime:$room_version"
   annotationProcessor "androidx.room:room-compiler:$room_version"
 

--- a/android/src/main/java/app/notifee/core/NotificationManager.java
+++ b/android/src/main/java/app/notifee/core/NotificationManager.java
@@ -634,13 +634,13 @@ class NotificationManager {
 
     PeriodicWorkRequest.Builder workRequestBuilder;
     workRequestBuilder =
-        new PeriodicWorkRequest.Builder(Worker.class, interval, trigger.getTimeUnit());
+        new PeriodicWorkRequest.Builder(Worker.class, interval, trigger.getTimeUnit()).setInitialDelay(interval, trigger.getTimeUnit());
 
     workRequestBuilder.addTag(Worker.WORK_TYPE_NOTIFICATION_TRIGGER);
     workRequestBuilder.addTag(uniqueWorkName);
     workRequestBuilder.setInputData(workDataBuilder.build());
     workManager.enqueueUniquePeriodicWork(
-        uniqueWorkName, ExistingPeriodicWorkPolicy.REPLACE, workRequestBuilder.build());
+        uniqueWorkName, ExistingPeriodicWorkPolicy.UPDATE, workRequestBuilder.build());
   }
 
   static void createTimestampTriggerNotification(
@@ -696,7 +696,7 @@ class NotificationManager {
       workDataBuilder.putString(Worker.KEY_WORK_REQUEST, Worker.WORK_REQUEST_PERIODIC);
       workRequestBuilder.setInputData(workDataBuilder.build());
       workManager.enqueueUniquePeriodicWork(
-          uniqueWorkName, ExistingPeriodicWorkPolicy.REPLACE, workRequestBuilder.build());
+          uniqueWorkName, ExistingPeriodicWorkPolicy.UPDATE, workRequestBuilder.build());
     }
   }
 

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   }
   implementation 'androidx.concurrent:concurrent-futures:1.1.0' // https://developer.android.com/jetpack/androidx/releases/concurrent
   implementation 'com.google.android.gms:play-services-tasks:18.0.1' // https://developers.google.com/android/guides/releases
-  implementation 'androidx.work:work-runtime:2.7.1' // https://developer.android.com/jetpack/androidx/releases/work
+  implementation 'androidx.work:work-runtime:2.8.0' // https://developer.android.com/jetpack/androidx/releases/work
   implementation 'org.greenrobot:eventbus:3.3.1' // https://github.com/greenrobot/EventBus/releases
 }
 


### PR DESCRIPTION
Fixes #696

- Interval triggers was missing initial delay
- Upgrades work manager and room db - there's no breaking changes and will help with maintenance 
- With work manager update, it's advised that `ExistingPeriodicWorkPolicy.REPLACE` is changed to `ExistingPeriodicWorkPolicy.UPDATE`