### PR TITLE
fix(android): pending intent unique id

### DIFF
--- a/android/src/main/java/app/notifee/core/NotificationPendingIntent.java
+++ b/android/src/main/java/app/notifee/core/NotificationPendingIntent.java
@@ -24,12 +24,13 @@ import android.os.Bundle;
 import app.notifee.core.event.MainComponentEvent;
 import app.notifee.core.model.NotificationAndroidPressActionModel;
 import app.notifee.core.utility.IntentUtils;
+
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class NotificationPendingIntent {
   public static final String EVENT_TYPE_INTENT_KEY = "notifee_event_type";
   public static final String NOTIFICATION_ID_INTENT_KEY = "notification_id";
-  private static final AtomicInteger uniqueIds = new AtomicInteger(0);
   private static final String TAG = "NotificationPendingIntent";
 
   /**
@@ -66,7 +67,7 @@ public class NotificationPendingIntent {
     setIntentExtras(receiverIntent, eventType, notificationId, extraKeys, extraBundles);
 
     // Create pending intent with activities
-    int uniqueInt = uniqueIds.getAndIncrement();
+    int uniqueInt = UUID.randomUUID().hashCode();
     Intent[] intents;
 
     if (launchActivityIntent != null) {


### PR DESCRIPTION
Fixes https://github.com/invertase/notifee/issues/637 https://github.com/invertase/notifee/issues/651

- uniqueId was always started from 0. As a result, uniqueId was sometimes duplicated
- uses uuid now to get a random number

thanks to @hibinoA for his help and contribution to fixing this issue