### PR TITLE
docs: fixing Notification data parameter type

### DIFF
--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -46,7 +46,7 @@ export interface Notification {
   body?: string | undefined;
 
   /**
-   * Additional data to store on the notification. Only `string` values can be stored.
+   * Additional data to store on the notification.
    *
    * Data can be used to provide additional context to your notification which can be retrieved
    * at a later point in time (e.g. via an event).


### PR DESCRIPTION
### Background:
The Notification interface **data** property type changed in [this](https://github.com/invertase/notifee/commit/32bce631a953eecd4211d0824ebf0940ba2e2b83#diff-0387e7fb23ad1a9deceecda23956f9e21006003f11f894eab30cd7f45428b118) pull request.
Values stored in the **data** object are no longer only strings according to the type.

### Change:
This pull request changes the **data** property documentation to reflect the change