### PR TITLE
feat(flutter): initial notification for iOS

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
@@ -58,12 +58,14 @@
 #pragma mark Application Notifications
 
 - (void)application_onDidFinishLaunchingNotification:(nonnull NSNotification *)notification {
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  NSDictionary *notifUserInfo = notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  NSDictionary *notifUserInfo =
+      notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
   UILocalNotification *launchNotification =
-         (UILocalNotification *)notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
-  [[NotifeeCoreUNUserNotificationCenter instance] onDidFinishLaunchingNotification: launchNotification.userInfo];
+      (UILocalNotification *)notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
+  [[NotifeeCoreUNUserNotificationCenter instance]
+      onDidFinishLaunchingNotification:launchNotification.userInfo];
   [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
 
   [[NotifeeCoreUNUserNotificationCenter instance] observe];

--- a/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
@@ -50,8 +50,6 @@
   });
 }
 
-// start observing immediately on class load - specifically for
-// UIApplicationDidFinishLaunchingNotification
 + (void)load {
   [[self instance] observe];
 }
@@ -60,8 +58,14 @@
 #pragma mark Application Notifications
 
 - (void)application_onDidFinishLaunchingNotification:(nonnull NSNotification *)notification {
-  // setup our delegates after app finishes launching
-  // these methods are idempotent so can safely be called multiple times
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  NSDictionary *notifUserInfo = notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
+  UILocalNotification *launchNotification =
+         (UILocalNotification *)notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
+  [[NotifeeCoreUNUserNotificationCenter instance] onDidFinishLaunchingNotification: launchNotification.userInfo];
+  [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
+
   [[NotifeeCoreUNUserNotificationCenter instance] observe];
 }
 

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.h
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>
+#import "NotifeeCore.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,12 +26,21 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, nullable, weak) id<UNUserNotificationCenterDelegate> originalDelegate;
 
 @property(strong, nullable) NSDictionary *initialNotification;
+@property bool initialNotificationGathered;
+@property(nullable) notifeeMethodNSDictionaryBlock initialNotificationBlock;
+@property NSString *initialNoticationID;
+@property NSString *notificationOpenedAppID;
 
 + (_Nonnull instancetype)instance;
 
 - (void)observe;
 
 - (nullable NSDictionary *)getInitialNotification;
+
+- (void)onDidFinishLaunchingNotification:(NSDictionary *)notification;
+
++ (UNMutableNotificationContent *)buildNotificationContent:(NSDictionary *)notification;
+
 
 @end
 

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.h
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.h
@@ -41,7 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (UNMutableNotificationContent *)buildNotificationContent:(NSDictionary *)notification;
 
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -177,8 +177,6 @@ struct {
   NSDictionary *notifeeNotification =
       response.notification.request.content.userInfo[kNotifeeUserInfoNotification];
 
-  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-  //  _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
   _notificationOpenedAppID = notifeeNotification[@"id"];
 
   // handle notification outside of notifee

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -48,20 +48,20 @@ struct {
     if (center.delegate != nil) {
       _originalDelegate = center.delegate;
       originalUNCDelegateRespondsTo.openSettingsForNotification = (unsigned int)[_originalDelegate
-                                                                                 respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
+          respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
       originalUNCDelegateRespondsTo.willPresentNotification = (unsigned int)[_originalDelegate
-                                                                             respondsToSelector:@selector(userNotificationCenter:
-                                                                                                          willPresentNotification:withCompletionHandler:)];
+          respondsToSelector:@selector(userNotificationCenter:
+                                      willPresentNotification:withCompletionHandler:)];
       originalUNCDelegateRespondsTo.didReceiveNotificationResponse =
-      (unsigned int)[_originalDelegate
-                     respondsToSelector:@selector(userNotificationCenter:
-                                                  didReceiveNotificationResponse:withCompletionHandler:)];
+          (unsigned int)[_originalDelegate
+              respondsToSelector:@selector(userNotificationCenter:
+                                     didReceiveNotificationResponse:withCompletionHandler:)];
     }
     center.delegate = strongSelf;
   });
 }
 
-- (void)onDidFinishLaunchingNotification: (nonnull NSDictionary *)notifUserInfo {
+- (void)onDidFinishLaunchingNotification:(nonnull NSDictionary *)notifUserInfo {
   if (notifUserInfo != nil) {
     NSDictionary *notifeeNotification = notifUserInfo[kNotifeeUserInfoNotification];
     _initialNoticationID = notifeeNotification[@"id"];
@@ -81,7 +81,7 @@ struct {
     } else {
       _initialNotificationBlock(nil, nil);
     }
-    
+
     _initialNotificationBlock = nil;
   }
 
@@ -176,9 +176,9 @@ struct {
              withCompletionHandler:(void (^)(void))completionHandler {
   NSDictionary *notifeeNotification =
       response.notification.request.content.userInfo[kNotifeeUserInfoNotification];
-  
+
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-//  _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
+  //  _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
   _notificationOpenedAppID = notifeeNotification[@"id"];
 
   // handle notification outside of notifee

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -33,6 +33,8 @@ struct {
   dispatch_once(&once, ^{
     sharedInstance = [[NotifeeCoreUNUserNotificationCenter alloc] init];
     sharedInstance.initialNotification = nil;
+    sharedInstance.initialNotificationGathered = false;
+    sharedInstance.initialNotificationBlock = nil;
   });
   return sharedInstance;
 }
@@ -46,24 +48,41 @@ struct {
     if (center.delegate != nil) {
       _originalDelegate = center.delegate;
       originalUNCDelegateRespondsTo.openSettingsForNotification = (unsigned int)[_originalDelegate
-          respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
+                                                                                 respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
       originalUNCDelegateRespondsTo.willPresentNotification = (unsigned int)[_originalDelegate
-          respondsToSelector:@selector(userNotificationCenter:
-                                      willPresentNotification:withCompletionHandler:)];
+                                                                             respondsToSelector:@selector(userNotificationCenter:
+                                                                                                          willPresentNotification:withCompletionHandler:)];
       originalUNCDelegateRespondsTo.didReceiveNotificationResponse =
-          (unsigned int)[_originalDelegate
-              respondsToSelector:@selector(userNotificationCenter:
-                                     didReceiveNotificationResponse:withCompletionHandler:)];
+      (unsigned int)[_originalDelegate
+                     respondsToSelector:@selector(userNotificationCenter:
+                                                  didReceiveNotificationResponse:withCompletionHandler:)];
     }
     center.delegate = strongSelf;
   });
 }
 
+- (void)onDidFinishLaunchingNotification: (nonnull NSDictionary *)notifUserInfo {
+  if (notifUserInfo != nil) {
+    NSDictionary *notifeeNotification = notifUserInfo[kNotifeeUserInfoNotification];
+    _initialNoticationID = notifeeNotification[@"id"];
+  }
+
+  _initialNotificationGathered = YES;
+}
+
 - (nullable NSDictionary *)getInitialNotification {
-  if (_initialNotification != nil) {
-    NSDictionary *initialNotificationCopy = [_initialNotification copy];
-    _initialNotification = nil;
-    return initialNotificationCopy;
+  if (_initialNotificationGathered && _initialNotificationBlock != nil) {
+    // copying initial notification
+    if (_initialNotification != nil &&
+        [_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
+      NSDictionary *initialNotificationCopy = [_initialNotification copy];
+      _initialNotification = nil;
+      _initialNotificationBlock(nil, initialNotificationCopy);
+    } else {
+      _initialNotificationBlock(nil, nil);
+    }
+    
+    _initialNotificationBlock = nil;
   }
 
   return nil;
@@ -157,6 +176,10 @@ struct {
              withCompletionHandler:(void (^)(void))completionHandler {
   NSDictionary *notifeeNotification =
       response.notification.request.content.userInfo[kNotifeeUserInfoNotification];
+  
+  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
+//  _notificationOpenedAppID = remoteNotification[@"gcm.message_id"];
+  _notificationOpenedAppID = notifeeNotification[@"id"];
 
   // handle notification outside of notifee
   if (notifeeNotification == nil) {
@@ -212,6 +235,12 @@ struct {
     _initialNotification = [eventDetail copy];
 
     // post PRESS/ACTION_PRESS event
+    // Set is initial notification to true
+    if (_notificationOpenedAppID != nil &&
+        [_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
+      eventDetail[@"initialNotification"] = @1;
+    }
+
     [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:event];
 
     // TODO figure out if this is needed or if we can just complete immediately

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -248,7 +248,7 @@
     if (notification[@"ios"][@"communicationInfo"] != nil) {
       INSendMessageIntent *intent = [NotifeeCoreUtil
           generateSenderIntentForCommunicationNotification:notification[@"ios"]
-                                                                         [@"communicationInfo"]];
+                                                                       [@"communicationInfo"]];
 
       // Use the intent to initialize the interaction.
       INInteraction *interaction = [[INInteraction alloc] initWithIntent:intent response:nil];
@@ -716,8 +716,8 @@
 }
 
 + (void)getInitialNotification:(notifeeMethodNSDictionaryBlock)block {
-   [NotifeeCoreUNUserNotificationCenter instance].initialNotificationBlock = block;
-   [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
+  [NotifeeCoreUNUserNotificationCenter instance].initialNotificationBlock = block;
+  [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
 }
 
 + (void)setBadgeCount:(NSInteger)count withBlock:(notifeeMethodVoidBlock)block {

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -716,7 +716,8 @@
 }
 
 + (void)getInitialNotification:(notifeeMethodNSDictionaryBlock)block {
-  block(nil, [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification]);
+   [NotifeeCoreUNUserNotificationCenter instance].initialNotificationBlock = block;
+   [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
 }
 
 + (void)setBadgeCount:(NSInteger)count withBlock:(notifeeMethodVoidBlock)block {

--- a/packages/flutter/packages/notifee/example/lib/main.dart
+++ b/packages/flutter/packages/notifee/example/lib/main.dart
@@ -77,6 +77,7 @@ class NotifeeExampleApp extends StatelessWidget {
       routes: {
         '/': (context) => const Application(),
         '/notification': (context) => const NotificationListItemView(),
+        '/initialNotification': (context) => const NotificationListItemView(),
         '/trigger_notification': (context) =>
             const TriggerNotificationListItemView(),
         '/trigger_notifications': (context) => const TriggerNotificationList(),

--- a/packages/flutter/packages/notifee/ios/Classes/NotifeePluginSwift.swift
+++ b/packages/flutter/packages/notifee/ios/Classes/NotifeePluginSwift.swift
@@ -155,6 +155,16 @@ public class NotifeePluginSwift: NSObject, FlutterPlugin, NotifeeCoreDelegate {
             }
         }
     }
+  
+    internal func getInitialNotification(result: @escaping FlutterResult) {
+        NotifeeCore.getInitialNotification { (error: Error?, notification: Any?) in
+            if error != nil {
+                result(error)
+            } else {
+                result(notification)
+            }
+        }
+    }
 
     internal func incrementBadgeCount(arguments: Int, result: @escaping FlutterResult) {
         NotifeeCore.incrementBadgeCount(arguments, with: { (error: Error?) in
@@ -199,6 +209,8 @@ public class NotifeePluginSwift: NSObject, FlutterPlugin, NotifeeCoreDelegate {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if call.method == "displayNotification" {
             displayNotification(arguments: call.arguments as! [String: Any], result: result)
+        } else if call.method == "getInitialNotification" {
+          getInitialNotification(result: result)
         } else if call.method == "createTriggerNotification" {
             createTriggerNotification(arguments: call.arguments as! [String: Any], result: result)
         } else if call.method == "cancelAllNotifications" {


### PR DESCRIPTION
Improves getInitialNotification for iOS as well as implementing it for Flutter. 

Even though it's not technically needed as there is an onForegroundEvent, it seems from the community feedback it is useful to keep. 
