### PR TITLE
fix: resolve type-error when running RN 0.72

### DIFF
--- a/packages/react-native/src/NotifeeNativeModule.ts
+++ b/packages/react-native/src/NotifeeNativeModule.ts
@@ -4,11 +4,11 @@
 
 import NotifeeJSEventEmitter from './NotifeeJSEventEmitter';
 import {
-  EventSubscriptionVendor,
   NativeEventEmitter,
   NativeModules,
   NativeModulesStatic,
 } from 'react-native';
+import { EventSubscriptionVendor } from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 export interface NativeModuleConfig {
   version: string;


### PR DESCRIPTION
This PR resolves a type error when using react-native 0.72.0. I believe this change should also work in RN 0.71.0 and older. This change ensures that we are still using `EventSubscriptionVendor` but we could also switch to `EventSubscription` instead if that is suitable for that case.