### PR TITLE
feat(iOS): run create and display notification in background thread

### DIFF
--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -16,6 +16,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <dispatch/dispatch.h>
 
 #import "Intents/Intents.h"
 #import "NotifeeCore+UNUserNotificationCenter.h"
@@ -176,49 +177,54 @@
  * @param block notifeeMethodVoidBlock
  */
 + (void)displayNotification:(NSDictionary *)notification withBlock:(notifeeMethodVoidBlock)block {
-  UNMutableNotificationContent *content = [self buildNotificationContent:notification
-                                                             withTrigger:nil];
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    UNMutableNotificationContent *content = [self buildNotificationContent:notification
+                                                               withTrigger:nil];
 
-  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
-  NSMutableDictionary *notificationDetail = [notification mutableCopy];
-  notificationDetail[@"remote"] = @NO;
+    NSMutableDictionary *notificationDetail = [notification mutableCopy];
+    notificationDetail[@"remote"] = @NO;
 
-  if (@available(iOS 15.0, *)) {
-    if (notification[@"ios"][@"communicationInfo"] != nil) {
-      INSendMessageIntent *intent = [NotifeeCoreUtil
-          generateSenderIntentForCommunicationNotification:notification[@"ios"]
-                                                                       [@"communicationInfo"]];
+    if (@available(iOS 15.0, *)) {
+      if (notification[@"ios"][@"communicationInfo"] != nil) {
+        INSendMessageIntent *intent = [NotifeeCoreUtil
+            generateSenderIntentForCommunicationNotification:notification[@"ios"]
+                                                                         [@"communicationInfo"]];
 
-      // Use the intent to initialize the interaction.
-      INInteraction *interaction = [[INInteraction alloc] initWithIntent:intent response:nil];
-      interaction.direction = INInteractionDirectionIncoming;
-      [interaction donateInteractionWithCompletion:^(NSError *error) {
-        if (error)
-          NSLog(@"NotifeeCore: Could not donate interaction for communication notification: %@",
-                error);
-      }];
+        // Use the intent to initialize the interaction.
+        INInteraction *interaction = [[INInteraction alloc] initWithIntent:intent response:nil];
+        interaction.direction = INInteractionDirectionIncoming;
+        [interaction donateInteractionWithCompletion:^(NSError *error) {
+          if (error)
+            NSLog(@"NotifeeCore: Could not donate interaction for communication notification: %@",
+                  error);
+        }];
 
-      content = [[content contentByUpdatingWithProvider:intent error:nil] mutableCopy];
+        content = [[content contentByUpdatingWithProvider:intent error:nil] mutableCopy];
+      }
     }
-  }
 
-  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:notification[@"id"]
-                                                                        content:content
-                                                                        trigger:nil];
+    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:notification[@"id"]
+                                                                          content:content
+                                                                          trigger:nil];
 
-  [center addNotificationRequest:request
-           withCompletionHandler:^(NSError *error) {
-             if (error == nil) {
-               [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
-                 @"type" : @(NotifeeCoreEventTypeDelivered),
-                 @"detail" : @{
-                   @"notification" : notificationDetail,
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [center addNotificationRequest:request
+               withCompletionHandler:^(NSError *error) {
+                 if (error == nil) {
+                   [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+                     @"type" : @(NotifeeCoreEventTypeDelivered),
+                     @"detail" : @{
+                       @"notification" : notificationDetail,
+                     }
+                   }];
                  }
+                 block(error);
                }];
-             }
-             block(error);
-           }];
+    });
+  });
+  
 }
 
 /* Create a trigger notification .
@@ -230,55 +236,63 @@
 + (void)createTriggerNotification:(NSDictionary *)notification
                       withTrigger:(NSDictionary *)trigger
                         withBlock:(notifeeMethodVoidBlock)block {
-  UNMutableNotificationContent *content = [self buildNotificationContent:notification
-                                                             withTrigger:trigger];
-  UNNotificationTrigger *unTrigger = [NotifeeCoreUtil triggerFromDictionary:trigger];
+  
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      UNMutableNotificationContent *content = [self buildNotificationContent:notification
+                                                                 withTrigger:trigger];
+      UNNotificationTrigger *unTrigger = [NotifeeCoreUtil triggerFromDictionary:trigger];
 
-  if (unTrigger == nil) {
-    // do nothing if trigger is null
-    return block(nil);
-  }
+      if (unTrigger == nil) {
+        // do nothing if trigger is null
+        return dispatch_async(dispatch_get_main_queue(), ^{
+          block(nil);
+        });
+      }
 
-  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+      UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
 
-  NSMutableDictionary *notificationDetail = [notification mutableCopy];
-  notificationDetail[@"remote"] = @NO;
+      NSMutableDictionary *notificationDetail = [notification mutableCopy];
+      notificationDetail[@"remote"] = @NO;
 
-  if (@available(iOS 15.0, *)) {
-    if (notification[@"ios"][@"communicationInfo"] != nil) {
-      INSendMessageIntent *intent = [NotifeeCoreUtil
-          generateSenderIntentForCommunicationNotification:notification[@"ios"]
-                                                                       [@"communicationInfo"]];
+      if (@available(iOS 15.0, *)) {
+        if (notification[@"ios"][@"communicationInfo"] != nil) {
+          INSendMessageIntent *intent = [NotifeeCoreUtil
+              generateSenderIntentForCommunicationNotification:notification[@"ios"]
+                                                                           [@"communicationInfo"]];
 
-      // Use the intent to initialize the interaction.
-      INInteraction *interaction = [[INInteraction alloc] initWithIntent:intent response:nil];
-      interaction.direction = INInteractionDirectionIncoming;
-      [interaction donateInteractionWithCompletion:^(NSError *error) {
-        if (error)
-          NSLog(@"NotifeeCore: Could not donate interaction for communication notification: %@",
-                error);
-      }];
+          // Use the intent to initialize the interaction.
+          INInteraction *interaction = [[INInteraction alloc] initWithIntent:intent response:nil];
+          interaction.direction = INInteractionDirectionIncoming;
+          [interaction donateInteractionWithCompletion:^(NSError *error) {
+            if (error)
+              NSLog(@"NotifeeCore: Could not donate interaction for communication notification: %@",
+                    error);
+          }];
 
-      content = [[content contentByUpdatingWithProvider:intent error:nil] mutableCopy];
-    }
-  }
+          content = [[content contentByUpdatingWithProvider:intent error:nil] mutableCopy];
+        }
+      }
 
-  UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:notification[@"id"]
-                                                                        content:content
-                                                                        trigger:unTrigger];
+      UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:notification[@"id"]
+                                                                            content:content
+                                                                            trigger:unTrigger];
 
-  [center addNotificationRequest:request
-           withCompletionHandler:^(NSError *error) {
-             if (error == nil) {
-               [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
-                 @"type" : @(NotifeeCoreEventTypeTriggerNotificationCreated),
-                 @"detail" : @{
-                   @"notification" : notificationDetail,
-                 }
-               }];
-             }
-             block(error);
-           }];
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [center addNotificationRequest:request
+                 withCompletionHandler:^(NSError *error) {
+                   if (error == nil) {
+                     [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+                       @"type" : @(NotifeeCoreEventTypeTriggerNotificationCreated),
+                       @"detail" : @{
+                         @"notification" : notificationDetail,
+                       }
+                     }];
+                   }
+                   block(error);
+                 }];
+      });
+    });
+  
 }
 
 /**


### PR DESCRIPTION
Thank you for this great library!

This pr is to not block the ui thread on iOS when sending attachments that needs to be downloaded before sending the notification. We experienced this and found #234 describing exactly the issue we had.