### PR TITLE
Make the Notification Trigger Channel ID type more clear

### DIFF
--- a/docs-react-native/react-native/docs/triggers.md
+++ b/docs-react-native/react-native/docs/triggers.md
@@ -38,7 +38,7 @@ function Screen() {
         title: 'Meeting with Jane',
         body: 'Today at 11:20am',
         android: {
-          channelId: 'your-channel-id',
+          channelId: yourChannelId,
         },
       },
       trigger,


### PR DESCRIPTION
Channel IDs are typically created using `notifee.createChannel`. Change the example naming to imply that it's not a simply a string that can be anything.