### PR TITLE
chore(android): add support for AGP 8 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,12 @@ ext {
 
 android {
   compileSdkVersion 33
+
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'app.notifee.core'
+  }
+
   testOptions {
     unitTests.returnDefaultValues = true
   }
@@ -75,9 +81,11 @@ android {
     }
   }
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+    }
   }
 
   testOptions.unitTests.all {

--- a/packages/flutter/packages/notifee/android/build.gradle
+++ b/packages/flutter/packages/notifee/android/build.gradle
@@ -27,6 +27,11 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 31
 
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpVersion >= 7) {
+      namespace 'io.flutter.plugins.notifee'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -62,6 +62,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.notifee'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }
@@ -69,10 +74,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+    }
   }
+
   buildTypes {
     release {
       consumerProguardFiles 'proguard-rules.pro'


### PR DESCRIPTION
Change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions). 

I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above. 

[See Kudo's comment on AGP 8 issues with BuildConfig and setting JVM versions.](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1677632448)

Not that I only updated the packages and not the example apps because Example apps aren't using AGP 8. 