### PR TITLE
fix(iOS): Allow the original delegate to handle non-Notifee notifications first

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -181,8 +181,13 @@ struct {
 
   // handle notification outside of notifee
   if (notifeeNotification == nil) {
-    notifeeNotification =
-        [NotifeeCoreUtil parseUNNotificationRequest:response.notification.request];
+    if (_originalDelegate != nil && originalUNCDelegateRespondsTo.didReceiveNotificationResponse) {
+      [_originalDelegate userNotificationCenter:center
+                 didReceiveNotificationResponse:response
+                          withCompletionHandler:completionHandler];
+    } else {
+      notifeeNotification = [NotifeeCoreUtil parseUNNotificationRequest:response.notification.request];
+    }
   }
 
   if (notifeeNotification != nil) {
@@ -247,11 +252,6 @@ struct {
                      completionHandler();
                    });
 
-  } else if (_originalDelegate != nil &&
-             originalUNCDelegateRespondsTo.didReceiveNotificationResponse) {
-    [_originalDelegate userNotificationCenter:center
-               didReceiveNotificationResponse:response
-                        withCompletionHandler:completionHandler];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "tests_rn:packager": "cd tests_react_native && npx react-native start",
     "tests_rn:packager:reset-cache": "cd tests_react_native && npx react-native start --reset-cache",
     "run:android": "cd tests_react_native && npx react-native run-android  --variant 'debug'",
-    "run:ios": "cd tests_react_native && npx react-native run-ios --scheme=Notifee --simulator 'iPhone 14'",
+    "run:ios": "cd tests_react_native && npx react-native run-ios --scheme=Notifee --simulator 'iPhone 15'",
     "tests_rn:test": "cd tests_react_native && jest",
     "tests_rn:test-watch": "cd tests_react_native && jest --watch",
     "tests_rn:test-coverage": "cd tests_react_native && jest --coverage",
     "tests_rn:android:build": "cd tests_react_native/android && ./gradlew assembleDebug -DtestBuildType=debug",
     "tests_rn:android:test": "cd tests_react_native && npm_config_yes=true npx cavy-cli run-android --no-jetifier",
-    "tests_rn:ios:test": "cd tests_react_native && npm_config_yes=true npx cavy-cli run-ios --scheme=Notifee --simulator 'iPhone 14'",
+    "tests_rn:ios:test": "cd tests_react_native && npm_config_yes=true npx cavy-cli run-ios --scheme=Notifee --simulator 'iPhone 15'",
     "tests_rn:ios:pod:install": "cd tests_react_native && npm_config_yes=true npx pod-install && cd .."
   },
   "devDependencies": {


### PR DESCRIPTION
## Issues

Fixes
* #925
* #984

## Overview

For notifications received when the app is backgrounded or killed in iOS (through `userNotificationCenter:didReceiveNotificationResponse:`), the original delegate is not invoked for non-Notifee notifications. The existing code attempts to parse the unknown notification into a format Notifee understands before giving the original delegate a chance to handle it.

I've moved up original delegate so that it handles a non-Notifee notification first (if it exists). If there is no original delegate, then we fall back to parsing the unknown notification and allowing Notifee to handle it.

## Testing

1. Jest tests all pass
2. iOS end-to-end tests all pass
3. I have an app that handles both [Iterable](https://support.iterable.com/hc/en-us/articles/360035018152-Iterable-s-iOS-SDK#_7-5-handle-incoming-push-notifications-and-enable-push-notification-tracking) and Notifee notifications.
    1. Before this change: The Iterable notification was being handled by Notifee, resulting in a default behavior of launching to the app home screen.
    2. After this change: Notifee falls back to the original delegate when encountering the Iterable notification, resulting in handling the notification correctly & launching the app to the correct screen.