### PR TITLE
fix: Remove EventSubscriptionVendor type use as it's removed in RN0.73

### DIFF
--- a/packages/react-native/src/NotifeeNativeModule.ts
+++ b/packages/react-native/src/NotifeeNativeModule.ts
@@ -4,7 +4,7 @@
 
 import NotifeeJSEventEmitter from './NotifeeJSEventEmitter';
 import {
-  EventSubscriptionVendor,
+  EventSubscription,
   NativeEventEmitter,
   NativeModules,
   NativeModulesStatic,
@@ -26,7 +26,7 @@ export default class NotifeeNativeModule {
     this._moduleConfig = Object.assign({}, config);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - change here needs resolution https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49560/files
-    this._nativeEmitter = new NativeEventEmitter(this.native as EventSubscriptionVendor);
+    this._nativeEmitter = new NativeEventEmitter(this.native as EventSubscription['subscriber']);
     for (let i = 0; i < config.nativeEvents.length; i++) {
       const eventName = config.nativeEvents[i];
       this._nativeEmitter.addListener(eventName, (payload: any) => {


### PR DESCRIPTION
EventSubscriptionVendor type is no longer being exported https://github.com/facebook/react-native/blob/02f163e4e83c3676216cd9360166e1cb0a8eda5f/packages/react-native/types/index.d.ts#L153