### PR TITLE
feat: group support to communication notifications

### DIFF
--- a/ios/NotifeeCore/NotifeeCoreUtil.m
+++ b/ios/NotifeeCore/NotifeeCoreUtil.m
@@ -738,15 +738,45 @@
                                                   contactIdentifier:nil
                                                    customIdentifier:nil];
 
+    NSMutableArray *recipients = nil;
+
+    INSpeakableString *speakableGroupName = nil;
+    if (communicationInfo[@"groupName"] != nil) {
+        speakableGroupName = [[INSpeakableString alloc] initWithSpokenPhrase:communicationInfo[@"groupName"]];
+
+        // For the `groupName` to work we need to have more than one recipient, otherwise, it won't be recognized
+        // as a group communication. For this reason, we are adding a placeholder person to the recipients which is
+        // not going to do any harm, the recipients are used as a fallback for when you don't have a `groupName`
+        // it concatenates the recipients name and then use that as a group name.
+        INPersonHandle *placeholderPersonHandle =
+                [[INPersonHandle alloc] initWithValue:@"placeholderId" type:INPersonHandleTypeUnknown];
+        INPerson *placeholderPerson = [[INPerson alloc] initWithPersonHandle:placeholderPersonHandle
+                                                     nameComponents:nil
+                                                        displayName:sender[@"displayName"]
+                                                              image:avatar
+                                                  contactIdentifier:nil
+                                                   customIdentifier:nil];
+        recipients = [NSMutableArray array];
+        [recipients addObject:senderPerson];
+        [recipients addObject:placeholderPerson];
+    }
+
     INSendMessageIntent *intent =
-        [[INSendMessageIntent alloc] initWithRecipients:nil
+        [[INSendMessageIntent alloc] initWithRecipients:recipients
                                     outgoingMessageType:INOutgoingMessageTypeOutgoingMessageText
                                                 content:communicationInfo[@"body"]
-                                     speakableGroupName:nil
+                                     speakableGroupName:speakableGroupName
                                  conversationIdentifier:communicationInfo[@"conversationId"]
                                             serviceName:nil
                                                  sender:senderPerson
                                             attachments:nil];
+
+    if (communicationInfo[@"groupAvatar"] != nil) {
+      NSURL *groupAvatarURL = [[NSURL alloc] initWithString:communicationInfo[@"groupAvatar"]];
+      INImage *groupAvatarImage = [INImage imageWithURL:groupAvatarURL];
+
+      [intent setImage:groupAvatarImage forParameterNamed:@"speakableGroupName"];
+    }
 
     return intent;
   }

--- a/packages/react-native/src/types/NotificationIOS.ts
+++ b/packages/react-native/src/types/NotificationIOS.ts
@@ -133,6 +133,8 @@ export interface NotificationIOS {
 export interface IOSCommunicationInfo {
   conversationId: string;
   body?: string;
+  groupName?: string;
+  groupAvatar?: string;
   sender: IOSCommunicationInfoPerson;
 }
 

--- a/packages/react-native/src/validators/iosCommunicationInfo/validateIOSCommunicationInfo.ts
+++ b/packages/react-native/src/validators/iosCommunicationInfo/validateIOSCommunicationInfo.ts
@@ -41,5 +41,21 @@ export default function validateIOSCommunicationInfo(
     out.body = communicationInfo.body;
   }
 
+  if (communicationInfo.groupName) {
+    if (!isString(communicationInfo.groupName)) {
+      throw new Error("'groupName' expected a valid string value.");
+    }
+
+    out.groupName = communicationInfo.groupName;
+  }
+
+  if (communicationInfo.groupAvatar) {
+    if (!isString(communicationInfo.groupAvatar)) {
+      throw new Error("'groupAvatar' expected a valid string value.");
+    }
+
+    out.groupAvatar = communicationInfo.groupAvatar;
+  }
+
   return out;
 }

--- a/tests_react_native/__tests__/validators/validateIOSNotification.test.ts
+++ b/tests_react_native/__tests__/validators/validateIOSNotification.test.ts
@@ -70,6 +70,7 @@ describe('Validate IOS Notification', () => {
       const $ = validateIOSNotification({
         communicationInfo: {
           conversationId: 'id',
+          groupName: "Friends",
           sender: {
             id: 'sender-id',
             displayName: 'John Doe',
@@ -79,6 +80,7 @@ describe('Validate IOS Notification', () => {
       expect($).toEqual({
         communicationInfo: {
           conversationId: 'id',
+          groupName: "Friends",
           sender: {
             id: 'sender-id',
             displayName: 'John Doe',

--- a/tests_react_native/example/notifications.ts
+++ b/tests_react_native/example/notifications.ts
@@ -70,6 +70,8 @@ export const notifications: { key: string; notification: Notification | Notifica
         categoryId: 'communicationId',
         communicationInfo: {
           conversationId: '123',
+          groupName: "Friends",
+          groupAvatar: 'https://pbs.twimg.com/profile_images/1070077650713133056/oji2RT4i_normal.jpg',
           sender: {
             id: 'abcde',
             avatar: 'https://pbs.twimg.com/profile_images/1070077650713133056/oji2RT4i_normal.jpg',

--- a/tests_react_native/sendPushNotification.js
+++ b/tests_react_native/sendPushNotification.js
@@ -25,6 +25,7 @@ var payload = {
         ios: {
           communicationInfo: {
             conversationId: 'id-abcde',
+            groupName: "Friends",
             sender: {
               id: 'senderId',
               avatar: 'https://placeimg.com/640/480/any',


### PR DESCRIPTION
Hey!

I was trying to add a subtitle/group name to my communication notifications and found out that notifee doesn't support it at the moment so in this PR I added support for it.

Related issues #889 #865

For context, here is an image of what I'm talking about:
![image](https://github.com/invertase/notifee/assets/3316818/4a964f44-9fac-4064-96f4-45b3e1222852)
