### PR TITLE
fix(android): Remove USE_FULL_SCREEN_INTENT as the default permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-  <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
   <uses-permission android:name="android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS" android:maxSdkVersion="30" />
   <!-- For Xiaomi devices to enable heads-up notifications as default (https://github.com/invertase/notifee/issues/296) -->

--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -251,6 +251,11 @@ export interface NotificationPressAction {
  * On Android; when provided to a notification action, the action will only open you application if
  * a `launchActivity` and/or a `mainComponent` is provided.
  *
+ * Requires the following permission to be added to your `AndroidManifest.xml`:
+ * ```xml
+ * <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+ * ```
+ *
  * Please see the [FullScreen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
  */
 export interface NotificationFullScreenAction {


### PR DESCRIPTION
Starting with Android 14 USE_FULL_SCREEN_INTENT is no longer allowed for most apps. It could be granted only to apps that provide calling and alarm functionalities.
A good way to solve this is to remove USE_FULL_SCREEN_INTENT by default and add a description for [NotificationFullScreenAction](https://notifee.app/react-native/reference/notificationfullscreenaction) that it needs `USE_FULL_SCREEN_INTENT`.

Please check if the docs show correctly because I've not found the way to run typedoc for that repo.

# FIxes
- Fixes #1027
- Fixes #1030