### PR TITLE
fix(android): support invalidate alongside deprecated onCatalystInstanceDestroy

### DIFF
--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -36,8 +36,17 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule implements Perm
     return Notifee.getInstance().getMainComponent(defaultComponent);
   }
 
-  @Override
+  // This method was removed upstream in react-native 0.74+, replaced with invalidate
+  // We will leave this stub here for older react-native versions compatibility
+  // ...but it will just delegate to the new invalidate method
   public void onCatalystInstanceDestroy() {
+    invalidate();
+  }
+
+  // This method was added in react-native 0.74 as a replacement for onCatalystInstanceDestroy
+  // It should be marked @Override but that would cause problems in apps using older react-native
+  // When minimum supported version is 0.74+ add @Override & remove onCatalystInstanceDestroy
+  public void invalidate() {
     NotifeeReactUtils.clearRunningHeadlessTasks();
   }
 


### PR DESCRIPTION

invalidate is the new way to have a hook called when react-native instances are going away, but onCatalystInstanceDestroy is still required for compatibility with older react-native versions