### PR TITLE
fix(ios): use new badge APIs to correctly clear badge on iOS18+

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -38,7 +38,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn Install
@@ -74,7 +74,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn Install
@@ -108,7 +108,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-with-website
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json') }}}-with-website
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn Install

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -71,21 +71,21 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json') }}
           restore-keys: ${{ runner.os }}-yarn-v1
 
       - uses: actions/cache@v4
         name: Gradle Cache
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-v1-${{ hashFiles('**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-v1--${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json', 'packages/react-native/android/build.gradle', 'tests_react_native/android/build.gradle', 'tests_react_native/android/app/build.gradle') }}
           restore-keys: ${{ runner.os }}-gradle-v1
 
       - uses: actions/cache@v4
         name: Cache Pods
         with:
           path: tests_react_native/ios/Pods
-          key: ${{ runner.os }}-pods-v2-${{ hashFiles('**/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-v2-${{ hashFiles('tests_react_native/ios/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-v2
 
       - name: Setup Ruby

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Start Simulator
         # The first time you try to `yarn run:ios` after xcode-select, it fails, so get it out of the way...
         continue-on-error: true
-        run: xcrun simctl boot "iPhone 15"
+        run: xcrun simctl boot "iPhone 16"
 
       # Set path variables needed for caches
       - name: Set workflow variables

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Yarn Install
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 15
           retry_wait_seconds: 60
           max_attempts: 4
           command: yarn --no-audit --prefer-offline && npm i -g cavy-cli

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -55,14 +55,14 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json') }}
           restore-keys: ${{ runner.os }}-yarn-v1
 
       - uses: actions/cache@v4
         name: Cache Pods
         with:
           path: tests_react_native/ios/Pods
-          key: ${{ runner.os }}-pods-v2-${{ hashFiles('**/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-v2-${{ hashFiles('tests_react_native/ios/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-v2
 
       - name: Setup Ruby

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -128,7 +128,7 @@ jobs:
         timeout-minutes: 30
         continue-on-error: true
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:/opt/homebrew/bin:$PATH"
           export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
           export CCACHE_FILECLONE=true
           export CCACHE_DEPEND=true
@@ -146,7 +146,7 @@ jobs:
         if: steps.run1.outcome=='failure'
         continue-on-error: true
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:/opt/homebrew/bin:$PATH"
           export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
           export CCACHE_FILECLONE=true
           export CCACHE_DEPEND=true
@@ -164,7 +164,7 @@ jobs:
         if: steps.run2.outcome=='failure'
         continue-on-error: true
         run: |
-          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:/opt/homebrew/bin:$PATH"
           export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
           export CCACHE_FILECLONE=true
           export CCACHE_DEPEND=true
@@ -198,7 +198,15 @@ jobs:
 
       - name: E2E Test
         timeout-minutes: 6
-        run: yarn tests_rn:ios:test
+        run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:/opt/homebrew/bin:$PATH"
+          export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
+          export CCACHE_FILECLONE=true
+          export CCACHE_DEPEND=true
+          export CCACHE_INODECACHE=true
+          ccache -s
+          yarn tests_rn:ios:test
+          ccache -s
 
       - name: Stop App Video
         if: always()

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -41,7 +41,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('package.json', 'packages/react-native/package.json', 'tests_react_native/package.json') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Yarn Install

--- a/.github/workflows/tests_junit.yml
+++ b/.github/workflows/tests_junit.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-v1
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/build.gradle*') }}-v1
 
       - name: Resolve Gradle Dependencies
         uses: nick-fields/retry@v3

--- a/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
@@ -60,8 +60,6 @@
 - (void)application_onDidFinishLaunchingNotification:(nonnull NSNotification *)notification {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  NSDictionary *notifUserInfo =
-      notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
   UILocalNotification *launchNotification =
       (UILocalNotification *)notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
   [[NotifeeCoreUNUserNotificationCenter instance]

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.h
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.h
@@ -39,8 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)onDidFinishLaunchingNotification:(NSDictionary *)notification;
 
-+ (UNMutableNotificationContent *)buildNotificationContent:(NSDictionary *)notification;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -21,6 +21,7 @@
 #import "NotifeeCoreUtil.h"
 
 @implementation NotifeeCoreUNUserNotificationCenter
+
 struct {
   unsigned int willPresentNotification : 1;
   unsigned int didReceiveNotificationResponse : 1;

--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -771,7 +771,8 @@
   if (![NotifeeCoreUtil isAppExtension]) {
     UIApplication *application = (UIApplication *)[NotifeeCoreUtil notifeeUIApplication];
     NSInteger currentCount = application.applicationIconBadgeNumber;
-    // If count was -1 to clear badge w/o clearing notifications, set currentCount to 0 before incrementing
+    // If count -1 (to clear badge w/o clearing notifications),
+    // set currentCount to 0 before incrementing
     if (currentCount == -1) {
       currentCount = 0;
     }

--- a/ios/NotifeeCore/NotifeeCoreUtil.m
+++ b/ios/NotifeeCore/NotifeeCoreUtil.m
@@ -690,7 +690,7 @@
     if ([content.sound isKindOfClass:[NSString class]]) {
       iosDict[@"sound"] = content.sound;
     } else if ([content.sound isKindOfClass:[NSDictionary class]]) {
-      NSDictionary *soundDict = content.sound;
+      NSDictionary *soundDict = (NSDictionary *)content.sound;
       NSMutableDictionary *notificationIOSSound = [[NSMutableDictionary alloc] init];
 
       // ios.sound.name String

--- a/package.json
+++ b/package.json
@@ -42,13 +42,13 @@
     "tests_rn:packager": "cd tests_react_native && npx react-native start",
     "tests_rn:packager:reset-cache": "cd tests_react_native && npx react-native start --reset-cache",
     "run:android": "cd tests_react_native && npx react-native run-android  --variant 'debug'",
-    "run:ios": "cd tests_react_native && npx react-native run-ios --scheme=Notifee --simulator 'iPhone 15'",
+    "run:ios": "cd tests_react_native && npx react-native run-ios --scheme=Notifee --simulator 'iPhone 16'",
     "tests_rn:test": "cd tests_react_native && jest",
     "tests_rn:test-watch": "cd tests_react_native && jest --watch",
     "tests_rn:test-coverage": "cd tests_react_native && jest --coverage",
     "tests_rn:android:build": "cd tests_react_native/android && ./gradlew assembleDebug -DtestBuildType=debug",
     "tests_rn:android:test": "cd tests_react_native && npm_config_yes=true npx cavy-cli run-android --no-jetifier",
-    "tests_rn:ios:test": "cd tests_react_native && npm_config_yes=true npx cavy-cli run-ios --scheme=Notifee --simulator 'iPhone 15'",
+    "tests_rn:ios:test": "cd tests_react_native && npm_config_yes=true npx cavy-cli run-ios --scheme=Notifee --simulator 'iPhone 16'",
     "tests_rn:ios:pod:install": "cd tests_react_native && npm_config_yes=true npx pod-install && cd .."
   },
   "devDependencies": {

--- a/packages/react-native/src/NotifeeNativeError.ts
+++ b/packages/react-native/src/NotifeeNativeError.ts
@@ -11,7 +11,6 @@ export default class NotifeeNativeError extends Error implements NativeError {
   private readonly jsStack: string;
 
   //  TODO native error type
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   constructor(nativeError: any, jsStack = '') {
     super();
     const { userInfo } = nativeError;
@@ -54,7 +53,6 @@ export default class NotifeeNativeError extends Error implements NativeError {
   }
 
   // todo errorEvent type
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   static fromEvent(errorEvent: any, stack?: string): NotifeeNativeError {
     return new NotifeeNativeError({ userInfo: errorEvent }, stack || new Error().stack);
   }

--- a/packages/react-native/src/types/NotificationAndroid.ts
+++ b/packages/react-native/src/types/NotificationAndroid.ts
@@ -193,7 +193,6 @@ export interface NotificationAndroid {
    * View the [Android Appearance](/react-native/docs/android/appearance#large-icons) documentation to learn
    * more about this property.
    */
-  /* eslint-disable-next-line @typescript-eslint/ban-types */
   largeIcon?: string | number | object;
 
   /**
@@ -601,7 +600,6 @@ export interface AndroidBigPictureStyle {
    * The image will be automatically resized depending on the device and it's size. If the image could
    * not be found a blank space will appear.
    */
-  /* eslint-disable-next-line @typescript-eslint/ban-types */
   picture: string | number | object;
 
   /**
@@ -616,7 +614,6 @@ export interface AndroidBigPictureStyle {
    *
    * To hide the `largeIcon` when the notification is expanded, set to null. Similar to `thumbnailHidden` for attachments on iOS.
    */
-  /* eslint-disable-next-line @typescript-eslint/ban-types */
   largeIcon?: string | number | object | null;
 
   /**

--- a/packages/react-native/src/utils/index.ts
+++ b/packages/react-native/src/utils/index.ts
@@ -7,7 +7,6 @@ import { Platform } from 'react-native';
 export * from './id';
 export * from './validate';
 
-/* eslint-disable-next-line @typescript-eslint/ban-types */
 export function isError(value: object): boolean {
   if (Object.prototype.toString.call(value) === '[object Error]') {
     return true;

--- a/packages/react-native/src/utils/validate.ts
+++ b/packages/react-native/src/utils/validate.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/ban-types */
 /*
  * Copyright (c) 2016-present Invertase Limited

--- a/packages/react-native/src/validators/validateAndroidNotification.ts
+++ b/packages/react-native/src/validators/validateAndroidNotification.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 /*
  * Copyright (c) 2016-present Invertase Limited
  */

--- a/tests_react_native/example/app.tsx
+++ b/tests_react_native/example/app.tsx
@@ -24,8 +24,8 @@ import Notifee, {
   EventType,
   Event,
   AuthorizationStatus,
-  TimestampTrigger,
-  RepeatFrequency,
+  // TimestampTrigger,
+  // RepeatFrequency,
 } from '@notifee/react-native';
 
 import { notifications } from './notifications';
@@ -92,8 +92,7 @@ async function onBackgroundMessage(message: RemoteMessage): Promise<void> {
 
 firebase.messaging().setBackgroundMessageHandler(onBackgroundMessage);
 function Root(): any {
-  // @ts-ignore
-  const [id, setId] = React.useState<string | null>(null);
+  const [id, _] = React.useState<string | null>(null);
 
   async function init(): Promise<void> {
     const fcmToken = await firebase.messaging().getToken();
@@ -174,13 +173,12 @@ function Root(): any {
 
       const date = new Date(Date.now());
       date.setSeconds(date.getSeconds() + 15);
-      // @ts-ignore
-      const trigger: TimestampTrigger = {
-        type: 0,
-        timestamp: date.getTime(),
-        alarmManager: true,
-        repeatFrequency: RepeatFrequency.HOURLY,
-      };
+      // const trigger: TimestampTrigger = {
+      //   type: 0,
+      //   timestamp: date.getTime(),
+      //   alarmManager: true,
+      //   repeatFrequency: RepeatFrequency.HOURLY,
+      // };
       // Notifee.createTriggerNotification(notification, trigger)
       //   .then(notificationId => setId(notificationId))
       //   .catch(console.error);

--- a/tests_react_native/ios/Podfile.lock
+++ b/tests_react_native/ios/Podfile.lock
@@ -351,10 +351,10 @@ PODS:
     - Firebase/Messaging (= 8.15.0)
     - React-Core
     - RNFBApp
-  - RNNotifee (7.8.2):
+  - RNNotifee (9.0.2):
     - NotifeeCore
     - React-Core
-  - RNNotifeeCore (7.8.2):
+  - RNNotifeeCore (9.0.2):
     - NotifeeCore
   - Yoga (1.14.0)
 
@@ -536,8 +536,8 @@ SPEC CHECKSUMS:
   ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
   RNFBApp: e4439717c23252458da2b41b81b4b475c86f90c4
   RNFBMessaging: 40dac204b4197a2661dec5be964780c6ec39bf65
-  RNNotifee: c7c0879cea45eed7718cb7fdd2ab02b45135f949
-  RNNotifeeCore: 389a7910056de4fef834064dd02560c64b7c8ff0
+  RNNotifee: 369bc03ba4785001e1c08bc8185ea82278bdb05a
+  RNNotifeeCore: f45f9d46428bf085201a3d7c0988a7abca3967c2
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
 
 PODFILE CHECKSUM: 0a7cc0c2dfdaa228004324b420c9bdc099bdf0b4

--- a/tests_react_native/specs/api.spec.ts
+++ b/tests_react_native/specs/api.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/valid-expect */
 import { expect } from 'chai';
 import { TestScope } from 'cavy';
 import notifee, {


### PR DESCRIPTION

Old workaround of using -1 on the application object no longer works

If iOS16+ use the new setBadge API and a real badge count of 0 and things appear to work

Also includes a series of commits that clean up lint errors all over, and fix up CI flakes

Peeled off from #510 as they were not related and that one will squash merge