### PR TITLE
fix(android): add guava transitive dep to module deps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -108,7 +108,7 @@ dependencies {
   api 'androidx.work:work-runtime:2.8.0' // https://developer.android.com/jetpack/androidx/releases/work
   api 'com.facebook.fresco:fresco:2.6.0' // https://github.com/facebook/fresco/releases
 
-  implementation("com.google.guava:guava:31.1-android") // https://github.com/google/guava
+  implementation("com.google.guava:guava:33.3.1-android") // https://github.com/google/guava
   implementation 'androidx.core:core:1.6.0'
 
   def room_version = '2.5.0' // https://developer.android.com/jetpack/androidx/releases/room

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -98,6 +98,8 @@ dependencies {
   } else {
     implementation(group: 'app.notifee', name:'core', version: '+')
   }
+
+  implementation("com.google.guava:guava:33.3.1-android") // https://github.com/google/guava
   implementation 'androidx.concurrent:concurrent-futures:1.1.0' // https://developer.android.com/jetpack/androidx/releases/concurrent
   implementation 'androidx.work:work-runtime:2.8.0' // https://developer.android.com/jetpack/androidx/releases/work
   implementation 'org.greenrobot:eventbus:3.3.1' // https://github.com/greenrobot/EventBus/releases


### PR DESCRIPTION
without this dep in the module build.gradle the transitive dep was absent in to the module so module users crashed on startup

also adopt guava 33.3.1 (current) vs 31.1

Fixes #1114 