### PR TITLE
fix(ios): Remote issues: #1041 / #1096 onForegroundEvent() and getInitialNotification()

### DIFF
--- a/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
@@ -58,13 +58,18 @@
 #pragma mark Application Notifications
 
 - (void)application_onDidFinishLaunchingNotification:(nonnull NSNotification *)notification {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  UILocalNotification *launchNotification =
-      (UILocalNotification *)notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
-  [[NotifeeCoreUNUserNotificationCenter instance]
-      onDidFinishLaunchingNotification:launchNotification.userInfo];
-  [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
+  NSDictionary *notifUserInfo =
+      notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
+    
+  if (!notifUserInfo) {
+      // Fallback to remote notification key if local notification key is not available
+      notifUserInfo = notification.userInfo[UIApplicationLaunchOptionsRemoteNotificationKey];
+  }
+
+  if (notifUserInfo) {
+      [[NotifeeCoreUNUserNotificationCenter instance] onDidFinishLaunchingNotification:notifUserInfo];
+      [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
+  }
 
   [[NotifeeCoreUNUserNotificationCenter instance] observe];
 }

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -21,7 +21,6 @@
 #import "NotifeeCoreUtil.h"
 
 @implementation NotifeeCoreUNUserNotificationCenter
-
 struct {
   unsigned int willPresentNotification : 1;
   unsigned int didReceiveNotificationResponse : 1;
@@ -104,7 +103,6 @@ struct {
   NSDictionary *notifeeNotification =
       notification.request.content.userInfo[kNotifeeUserInfoNotification];
 
-  // we only care about notifications created through notifee
   if (notifeeNotification != nil) {
     UNNotificationPresentationOptions presentationOptions = UNNotificationPresentationOptionNone;
     NSDictionary *foregroundPresentationOptions =
@@ -148,23 +146,16 @@ struct {
       presentationOptions |= UNNotificationPresentationOptionAlert;
     }
 
-    NSDictionary *notifeeTrigger = notification.request.content.userInfo[kNotifeeUserInfoTrigger];
-    if (notifeeTrigger != nil) {
-      // post DELIVERED event
-      [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+    // post DELIVERED event
+    [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
         @"type" : @(NotifeeCoreEventTypeDelivered),
         @"detail" : @{
           @"notification" : notifeeNotification,
         }
-      }];
-    }
+    }];
 
     completionHandler(presentationOptions);
 
-  } else if (_originalDelegate != nil && originalUNCDelegateRespondsTo.willPresentNotification) {
-    [_originalDelegate userNotificationCenter:center
-                      willPresentNotification:notification
-                        withCompletionHandler:completionHandler];
   }
 }
 

--- a/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -83,7 +83,7 @@ struct {
 
       _initialNotification = nil;
 
-      // Runs getInitialNotification() on JavaScript side with payload:
+      // Sets the return payload for getInitialNotification()
       _initialNotificationBlock(nil, initialNotificationCopy);
 
       // Prepare onForegroundEvent() payload


### PR DESCRIPTION
### 👋 Hello!

### This PR fixes 
- #912 
- 🤔 Perhaps #999 
- #1041
- #1076
- #1096.
-  #1109 

🙏 Please keep in mind I just learned Objective C and Swift in order to fix those issues.

### What's changed?

- [`onForeground()` is called with `getInitialNotification()`](https://github.com/invertase/notifee/pull/1118/files#diff-ec80c62b93aed0afa4addac8a6cd5fb6534543b3cc39bbd1b706adb9ec82a1ccR97-R98) for `PRESS` and `PRESS_ACTION` events when app is opened from a terminated state.
- [remote payload is picked up when local payload is not available](https://github.com/invertase/notifee/pull/1118/files#diff-e6cee9e1068ee77f7db69b7ee7ccfecefab70ddee393961f93eeeb034d4919afL61-L67). Thanks to this, `getInitialNotification()` will return the correct payload on app start.
- With the above, I think this [code will be unreachable so I removed it](https://github.com/invertase/notifee/pull/1118/files#diff-ec80c62b93aed0afa4addac8a6cd5fb6534543b3cc39bbd1b706adb9ec82a1ccL164-L167)
- `onForeground()`  is called for `DELIVERED` events by [removing this condition](https://github.com/invertase/notifee/pull/1118/files#diff-ec80c62b93aed0afa4addac8a6cd5fb6534543b3cc39bbd1b706adb9ec82a1ccL151-L152), but I have mixed feelings about it. Might need a deeper look.


### How to test
1. Be sure to [configure Notifee to handle remote notifications](https://notifee.app/react-native/docs/ios/remote-notification-support)
2. If you're using [`patch-package`](https://www.npmjs.com/package/patch-package), in your `patches` folder create a file called `@notifee+react-native+9.1.1.patch`
3. Paste the following:


```diff
diff --git a/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m b/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
index 560a62c..c010367 100644
--- a/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
+++ b/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+NSNotificationCenter.m
@@ -58,13 +58,18 @@
 #pragma mark Application Notifications
 
 - (void)application_onDidFinishLaunchingNotification:(nonnull NSNotification *)notification {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  UILocalNotification *launchNotification =
-      (UILocalNotification *)notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
-  [[NotifeeCoreUNUserNotificationCenter instance]
-      onDidFinishLaunchingNotification:launchNotification.userInfo];
-  [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
+  NSDictionary *notifUserInfo =
+      notification.userInfo[UIApplicationLaunchOptionsLocalNotificationKey];
+    
+  if (!notifUserInfo) {
+      // Fallback to remote notification key if local notification key is not available
+      notifUserInfo = notification.userInfo[UIApplicationLaunchOptionsRemoteNotificationKey];
+  }
+
+  if (notifUserInfo) {
+      [[NotifeeCoreUNUserNotificationCenter instance] onDidFinishLaunchingNotification:notifUserInfo];
+      [[NotifeeCoreUNUserNotificationCenter instance] getInitialNotification];
+  }
 
   [[NotifeeCoreUNUserNotificationCenter instance] observe];
 }
diff --git a/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m b/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
index beaa360..ff53bef 100644
--- a/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
+++ b/node_modules/@notifee/react-native/ios/NotifeeCore/NotifeeCore+UNUserNotificationCenter.m
@@ -21,7 +21,6 @@
 #import "NotifeeCoreUtil.h"
 
 @implementation NotifeeCoreUNUserNotificationCenter
-
 struct {
   unsigned int willPresentNotification : 1;
   unsigned int didReceiveNotificationResponse : 1;
@@ -73,12 +72,31 @@ struct {
 
 - (nullable NSDictionary *)getInitialNotification {
   if (_initialNotificationGathered && _initialNotificationBlock != nil) {
+
     // copying initial notification
     if (_initialNotification != nil &&
         [_initialNoticationID isEqualToString:_notificationOpenedAppID]) {
-      NSDictionary *initialNotificationCopy = [_initialNotification copy];
+
+      NSMutableDictionary *event = [NSMutableDictionary dictionary];
+      NSMutableDictionary *initialNotificationCopy = [_initialNotification mutableCopy];
+      initialNotificationCopy[@"initialNotification"] = @1;
+
       _initialNotification = nil;
-      _initialNotificationBlock(nil, initialNotificationCopy);
+
+      // Sets the return payload for getInitialNotification()
+     _initialNotificationBlock(nil, initialNotificationCopy);
+
+      // Prepare onForegroundEvent() payload
+      event[@"detail"] = [initialNotificationCopy copy];
+      if ([event[@"detail"][@"pressAction"][@"id"] isEqualToString:@"default"]) {
+          event[@"type"] = @1;  // PRESS
+      } else {
+          event[@"type"] = @2;  // ACTION_PRESS
+      }
+
+      // Call onForegroundEvent() on Javascript side with payload:
+      [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:event];
+
     } else {
       _initialNotificationBlock(nil, nil);
     }
@@ -104,7 +122,6 @@ struct {
   NSDictionary *notifeeNotification =
       notification.request.content.userInfo[kNotifeeUserInfoNotification];
 
-  // we only care about notifications created through notifee
   if (notifeeNotification != nil) {
     UNNotificationPresentationOptions presentationOptions = UNNotificationPresentationOptionNone;
     NSDictionary *foregroundPresentationOptions =
@@ -148,23 +165,16 @@ struct {
       presentationOptions |= UNNotificationPresentationOptionAlert;
     }
 
-    NSDictionary *notifeeTrigger = notification.request.content.userInfo[kNotifeeUserInfoTrigger];
-    if (notifeeTrigger != nil) {
-      // post DELIVERED event
-      [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
+    // post DELIVERED event
+    [[NotifeeCoreDelegateHolder instance] didReceiveNotifeeCoreEvent:@{
         @"type" : @(NotifeeCoreEventTypeDelivered),
         @"detail" : @{
           @"notification" : notifeeNotification,
         }
-      }];
-    }
+    }];
 
     completionHandler(presentationOptions);
 
-  } else if (_originalDelegate != nil && originalUNCDelegateRespondsTo.willPresentNotification) {
-    [_originalDelegate userNotificationCenter:center
-                      willPresentNotification:notification
-                        withCompletionHandler:completionHandler];
   }
 }
 

```