### PR TITLE
fix: Add missing createChannels mock.

### DIFF
--- a/packages/react-native/jest-mock.js
+++ b/packages/react-native/jest-mock.js
@@ -136,6 +136,7 @@ export default {
   cancelDisplayedNotification: jest.fn(async () => {}),
   cancelTriggerNotification: jest.fn(async () => {}),
   createChannel: jest.fn(async channel => channel?.id || testChannel.id),
+  createChannels: jest.fn(async () => {}),
   createChannelGroup: jest.fn(async channelGroup => channelGroup?.id || testChannelGroup.id),
   createChannelGroups: jest.fn(async () => {}),
   deleteChannel: jest.fn(async () => {}),


### PR DESCRIPTION
Hi there,

Just a minor addition to the jest-mock for the react-native package.
The `createChannels` method was missing a mock implementation, which was a bit of a head-scratcher in tests until I tracked it down to here.

Cheers.