### PR TITLE
fix(android): add error handling for POST_NOTIFICATIONS permission request (#1064)

### DIFF
--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -273,10 +273,17 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule implements Perm
         .setRequestPermissionCallback(
             (e, aBundle) -> NotifeeReactUtils.promiseResolver(promise, e, aBundle));
 
-    activity.requestPermissions(
-        new String[] {Manifest.permission.POST_NOTIFICATIONS},
-        Notifee.REQUEST_CODE_NOTIFICATION_PERMISSION,
-        this);
+    try {
+      activity.requestPermissions(
+          new String[] {Manifest.permission.POST_NOTIFICATIONS},
+          Notifee.REQUEST_CODE_NOTIFICATION_PERMISSION,
+          this);
+    } catch (Exception e) {
+      Logger.d(
+          "requestPermission",
+          "Failed to request POST_NOTIFICATIONS permission: " + e.getMessage());
+      NotifeeReactUtils.promiseResolver(promise, e);
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
### Summary
This PR addresses a potential race condition in the `requestPermission` method within `NotifeeApiModule.java`. The issue likely arises when the `View` or `Activity` is no longer available due to a user dismissal or other lifecycle changes before the permission request can be completed. This can lead to a `NullPointerException` crash when the code tries to access the `View` or `Activity`.

### Issue Details
In cases where the `View` or `Activity` is null by the time `requestPermission` is invoked, the lack of exception handling causes the app to crash. This PR wraps the permission request in a `try-catch` block to handle such scenarios gracefully and prevent crashes. Logging the exception provides a way to trace issues when they occur, and rejecting the promise enables the app code to manage the error condition.

### Changes
- **Added try-catch**: Wrapped `activity.requestPermissions()` in a `try-catch` block to catch any exceptions and avoid unexpected crashes.
- **Detailed error logging**: Logged a clear error message in case of failure, including details from the exception.
- **Promise rejection on failure**: Used `NotifeeReactUtils.promiseResolver` to reject the promise if the permission request fails, allowing the calling code to handle the error as needed.

Fixes: #1064 

