### PR TITLE
fix(android): preserve new-arch classnames used in backwards-compat logic

### DIFF
--- a/docs-react-native/react-native/docs/installation.md
+++ b/docs-react-native/react-native/docs/installation.md
@@ -22,12 +22,12 @@ yarn add @notifee/react-native
 
 ### 2a. Android API versions
 
-The values of the compileSdkVersion & targetSdkVersion might need to be changed. compileSdkVersion needs to be at least 33. In addition, if your app is going to request permission on Android 13 via requestPermission, targetSdkVersion needs to be at least 33, as well. These setting are in the file `/android/build.gradle`. 
+The values of the compileSdkVersion & targetSdkVersion might need to be changed. compileSdkVersion needs to be at least 34. In addition, if your app is going to request permission on Android 13 via requestPermission, targetSdkVersion needs to be at least 33, as well. These setting are in the file `/android/build.gradle`.
 
 ```gradle
 buildscript {
   ext {
-    compileSdkVersion = 33 // at least 33
+    compileSdkVersion = 34 // at least 34
     targetSdkVersion = 33 // If requesting permission on Android 13 via requestPermission, at least 33 
     ... 
  } 

--- a/packages/react-native/android/proguard-rules.pro
+++ b/packages/react-native/android/proguard-rules.pro
@@ -1,8 +1,16 @@
 -keep class io.invertase.notifee.NotifeeEventSubscriber
 -keep class io.invertase.notifee.NotifeeInitProvider
--keepnames class com.facebook.react.ReactActivity
 -keepnames class io.invertase.notifee.NotifeePackage
 -keepnames class io.invertase.notifee.NotifeeApiModule
+
+# We depend on certain classes to exist under their names for dynamic
+# class-loading to work. We use this to handle new arch / old arch backwards
+# compatibility despite the class names moving around
+-keep class com.facebook.react.defaults.DefaultNewArchitectureEntryPoint { *; }
+-keep class com.facebook.react.ReactApplication { *; }
+-keep class com.facebook.react.ReactHost { *; }
+-keep class * extends com.facebook.react.ReactHost { *; }
+-keepnames class com.facebook.react.ReactActivity
 
 # Preserve all annotations.
 -keepattributes *Annotation*

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
@@ -118,7 +118,7 @@ class NotifeeReactUtils {
         Method bridgelessEnabled = entryPoint.getMethod("getBridgelessEnabled");
         Object result = bridgelessEnabled.invoke(null);
         if (result == Boolean.TRUE) {
-          Log.d("getReactContext", "We are in bridgeless new architecture mode");
+          Log.d("Notifee::getReactContext", "We are in bridgeless new architecture mode");
           Object reactApplication = EventSubscriber.getContext();
           Method getReactHost = reactApplication.getClass().getMethod("getReactHost");
           Object reactHostInstance = getReactHost.invoke(reactApplication);
@@ -126,22 +126,22 @@ class NotifeeReactUtils {
               reactHostInstance.getClass().getMethod("getCurrentReactContext");
           return (ReactContext) getCurrentReactContext.invoke(reactHostInstance);
         } else {
-          Log.d("getReactContext", "we are NOT in bridgeless new architecture mode");
+          Log.d("Notifee::getReactContext", "we are NOT in bridgeless new architecture mode");
         }
       } catch (Exception e) {
-        Log.d("getReactContext", "New Architecture class load failed. Using fallback.");
+        Log.d("Notifee::getReactContext", "New Architecture class load failed. Using fallback.");
       }
 
-      Log.d("getReactContext", "Determining ReactContext using fallback method");
+      Log.d("Notifee::getReactContext", "Determining ReactContext using fallback method");
       ReactNativeHost reactNativeHost =
           ((ReactApplication) EventSubscriber.getContext()).getReactNativeHost();
       ReactInstanceManager reactInstanceManager = reactNativeHost.getReactInstanceManager();
       return reactInstanceManager.getCurrentReactContext();
     } catch (Exception e) {
-      Log.w("getReactContext", "ReactHost unexpectedly null", e);
+      Log.w("Notifee::getReactContext", "ReactHost unexpectedly null", e);
     }
 
-    Log.w("getReactContext", "Unable to determine ReactContext");
+    Log.w("Notifee::getReactContext", "Unable to determine ReactContext");
     return null;
   }
 


### PR DESCRIPTION

We use dynamic class-loading via reflection to determine if we are in new architecture mode or not and load the ReactContext

If we don't correctly preserve those names in minimization, we will crash in a new architecture context on release builds as the class names will have moved during the minimization