### PR TITLE
chore(android)!: forward-port to new architecture method

### DIFF
--- a/docs-react-native/react-native/docs/installation.md
+++ b/docs-react-native/react-native/docs/installation.md
@@ -22,12 +22,12 @@ yarn add @notifee/react-native
 
 ### 2a. Android API versions
 
-The values of the compileSdkVersion & targetSdkVersion might need to be changed. compileSdkVersion needs to be at least 33. In addition, if your app is going to request permission on Android 13 via requestPermission, targetSdkVersion needs to be at least 33, as well. These setting are in the file `/android/build.gradle`. 
+The values of the compileSdkVersion & targetSdkVersion might need to be changed. compileSdkVersion needs to be at least 34. In addition, if your app is going to request permission on Android 13 via requestPermission, targetSdkVersion needs to be at least 33, as well. These setting are in the file `/android/build.gradle`.
 
 ```gradle
 buildscript {
   ext {
-    compileSdkVersion = 33 // at least 33
+    compileSdkVersion = 34 // at least 34
     targetSdkVersion = 33 // If requesting permission on Android 13 via requestPermission, at least 33 
     ... 
  } 

--- a/packages/react-native/android/proguard-rules.pro
+++ b/packages/react-native/android/proguard-rules.pro
@@ -1,8 +1,16 @@
 -keep class io.invertase.notifee.NotifeeEventSubscriber
 -keep class io.invertase.notifee.NotifeeInitProvider
--keepnames class com.facebook.react.ReactActivity
 -keepnames class io.invertase.notifee.NotifeePackage
 -keepnames class io.invertase.notifee.NotifeeApiModule
+
+# We depend on certain classes to exist under their names for dynamic
+# class-loading to work. We use this to handle new arch / old arch backwards
+# compatibility despite the class names moving around
+-keep class com.facebook.react.defaults.DefaultNewArchitectureEntryPoint { *; }
+-keep class com.facebook.react.ReactApplication { *; }
+-keep class com.facebook.react.ReactHost { *; }
+-keep class * extends com.facebook.react.ReactHost { *; }
+-keepnames class com.facebook.react.ReactActivity
 
 # Preserve all annotations.
 -keepattributes *Annotation*

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
@@ -215,7 +215,8 @@ class NotifeeReactUtils {
     try {
       ReactContext reactContext = getReactContext();
 
-      if (reactContext == null || !reactContext.hasActiveCatalystInstance()) {
+      // hasActiveReactInstance method introduced in react-native 0.65 / August 2021
+      if (reactContext == null || !reactContext.hasActiveReactInstance()) {
         return;
       }
 

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
@@ -118,7 +118,7 @@ class NotifeeReactUtils {
         Method bridgelessEnabled = entryPoint.getMethod("getBridgelessEnabled");
         Object result = bridgelessEnabled.invoke(null);
         if (result == Boolean.TRUE) {
-          Log.d("getReactContext", "We are in bridgeless new architecture mode");
+          Log.d("Notifee::getReactContext", "We are in bridgeless new architecture mode");
           Object reactApplication = EventSubscriber.getContext();
           Method getReactHost = reactApplication.getClass().getMethod("getReactHost");
           Object reactHostInstance = getReactHost.invoke(reactApplication);
@@ -126,22 +126,22 @@ class NotifeeReactUtils {
               reactHostInstance.getClass().getMethod("getCurrentReactContext");
           return (ReactContext) getCurrentReactContext.invoke(reactHostInstance);
         } else {
-          Log.d("getReactContext", "we are NOT in bridgeless new architecture mode");
+          Log.d("Notifee::getReactContext", "we are NOT in bridgeless new architecture mode");
         }
       } catch (Exception e) {
-        Log.d("getReactContext", "New Architecture class load failed. Using fallback.");
+        Log.d("Notifee::getReactContext", "New Architecture class load failed. Using fallback.");
       }
 
-      Log.d("getReactContext", "Determining ReactContext using fallback method");
+      Log.d("Notifee::getReactContext", "Determining ReactContext using fallback method");
       ReactNativeHost reactNativeHost =
           ((ReactApplication) EventSubscriber.getContext()).getReactNativeHost();
       ReactInstanceManager reactInstanceManager = reactNativeHost.getReactInstanceManager();
       return reactInstanceManager.getCurrentReactContext();
     } catch (Exception e) {
-      Log.w("getReactContext", "ReactHost unexpectedly null", e);
+      Log.w("Notifee::getReactContext", "ReactHost unexpectedly null", e);
     }
 
-    Log.w("getReactContext", "Unable to determine ReactContext");
+    Log.w("Notifee::getReactContext", "Unable to determine ReactContext");
     return null;
   }
 


### PR DESCRIPTION

Forward-port away from deprecated react-native methods

The ones we need to use now were added in react-native 0.65

https://github.com/facebook/react-native/commit/dfa8eb0558338f18ea01f294a64d355f6deeff06

react-native 0.65 was released in August 2021 so this shouldn't actually affect anyone but every time I think that I am surprised

Blocking this one pending other breaking changes, as there is not a pressing need to release it now, I just noticed it while troubleshooting and testing #1149 