### PR TITLE
docs: removed the instruction to add @notifee/react-native to the list of expo plugins 

### DIFF
--- a/docs-react-native/react-native/docs/installation.md
+++ b/docs-react-native/react-native/docs/installation.md
@@ -66,7 +66,6 @@ If, however, you're currently compiling your app for SDK version lower than 33, 
 
 `npx expo install expo-build-properties`
 
-Then, add `@notifee/react-native` to the list of plugins in your app's Expo config (`app.json` or `app.config.js`):
 ```js
 {
   "name": "my app",


### PR DESCRIPTION

As the @notifee/react-native expo plugin is removed this line is misleading