### PR TITLE
fix(android): fix headless crash with null ReactContext

### DIFF
--- a/packages/react-native/android/src/main/java/io/invertase/notifee/HeadlessTask.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/HeadlessTask.java
@@ -1,0 +1,419 @@
+/*
+ * This software has been integrated, with great appreciation, from the
+ * react-native-background-geolocation library, and was originally authored by
+ * Chris Scott @ TransistorSoft. It is published in that repository under this license,
+ * included here in it's entirety
+ *
+ * https://github.com/transistorsoft/react-native-background-geolocation/blob/master/LICENSE
+ *
+ * ----
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Chris Scott
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.invertase.notifee;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import app.notifee.core.EventSubscriber;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceEventListener;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+import com.facebook.react.jstasks.HeadlessJsTaskContext;
+import com.facebook.react.jstasks.HeadlessJsTaskEventListener;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/*
+ * The BackgroundGeolocation SDK creates a single instance of this class (via reflection upon Config.headlessJobService)
+ * The SDK delivers events to this instance by dropping them onto EventBus (see @Subscribe).  Because this instance is subscribed
+ * into EventBus, it's protected from GC.
+ *
+ * Because there's only one instance of this class, we have to be mindful that we can possibly receive events rapidly,
+ * so we store them in a Queue (#mTaskQueue).
+ *
+ * We also have to be mindful that it's a heavy operation to do the initial launch the ReactNative Host, so several events
+ * might build up in the queue before the Host is finally launched, when we drain the queue (see #drainTaskQueue).
+ *
+ * For finally sending events to the client, we wrap the RN HeadlessJsTaskConfig with our own TaskConfig class.  This class
+ * adds our own auto-incremented "taskId" field to maintain a mapping between our taskId and RN's.  See #invokeStartTask.
+ * This class appends our custom taskId into the the event params sent to Javascript, for the following purpose:
+ *
+ * ```javascript
+ * const BackgroundGeolocationHeadlessTask = async (event) => {
+ *   console.log('[HeadlessTask] taskId: ', event.taskId);  // <-- here's our custom taskId.
+ *
+ *   await doWork();  // <-- perform some arbitrarily long process (eg: http request).
+ *
+ *   BackgroundGeolocation.finishHeadlessTask(event.taskId);  // <-- $$$ Here's the money $$$
+ * }
+ * ```
+ *
+ * See "Here's the $money" above: We want to signal back to this native HeadlessTask instance , that our JS task is now complete.
+ * This is a pretty easy task to do via EventBus -- Just create a new instance of FinishHeadlessTaskEvent(params.taskId);
+ *
+ * The code then looks up a TaskConfig from mEventQueue using the given event.taskId.
+ *
+ * All this extra fussing with taking care to finish our RN HeadlessTasks seems to be more important with RN's "new architecture", where before,
+ * RN seemed to automatically complete its tasks seemingly when the Javascript function stopped executing.  This is why it was always so
+ * important to await one's Promises and do all the work before the the last line of the function executed.
+ *
+ * Now, the Javascript must explicitly call back to the native side to say "I'M DONE" -- BackgroundGeolocation.finishHeadlessTask(taskId)
+ *
+ * Created by chris on 2018-01-23.
+ */
+
+public class HeadlessTask {
+  private static String HEADLESS_TASK_NAME = "NotifeeHeadlessJS";
+  // Hard-coded time-limit for headless-tasks is 60000 @todo configurable?
+  private static final int TASK_TIMEOUT = 60000;
+  private static final AtomicInteger sLastTaskId = new AtomicInteger(0);
+
+  static synchronized int getNextTaskId() {
+    return sLastTaskId.incrementAndGet();
+  }
+
+  private final List<TaskConfig> mTaskQueue = new ArrayList<>();
+  private final AtomicBoolean mIsReactContextInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean mIsInitializingReactContext = new AtomicBoolean(false);
+  private final AtomicBoolean mIsHeadlessJsTaskListenerRegistered = new AtomicBoolean(false);
+
+  public void stopAllTasks() {
+    for (TaskConfig task : mTaskQueue) {
+      onFinishHeadlessTask(task.getTaskId());
+    }
+  }
+
+  /**
+   * EventBus Receiver. Called when developer runs BackgroundGeolocation.finishHeadlessTask(taskId)
+   * from within their registered HeadlessTask. Calls RN's HeadlessJsTaskContext.finishTask(taskId);
+   *
+   * @param taskId the taskId returned from startTask
+   */
+  public void onFinishHeadlessTask(int taskId) {
+    if (!mIsReactContextInitialized.get()) {
+      Log.w("NotifeeHeadlessJS", taskId + " found no ReactContext");
+      return;
+    }
+    ReactContext reactContext = getReactContext(EventSubscriber.getContext());
+    if (reactContext != null) {
+
+      synchronized (mTaskQueue) {
+        // Locate the TaskConfig instance by our local taskId.
+        TaskConfig taskConfig = null;
+        for (TaskConfig config : mTaskQueue) {
+          if (config.getTaskId() == taskId) {
+            taskConfig = config;
+            break;
+          }
+        }
+        if (taskConfig != null) {
+          HeadlessJsTaskContext headlessJsTaskContext =
+              HeadlessJsTaskContext.getInstance(reactContext);
+          // Tell RN we're done using the mapped getReactTaskId().
+          headlessJsTaskContext.finishTask(taskConfig.getReactTaskId());
+        } else {
+          Log.w("NotifeeHeadlessJS", "Failed to find task: " + taskId);
+        }
+      }
+    } else {
+      Log.w(
+          "NotifeeHeadlessJS",
+          "Failed to finishHeadlessTask: "
+              + taskId
+              + " -- HeadlessTask onFinishHeadlessTask failed to find a ReactContext.  This is"
+              + " unexpected");
+    }
+  }
+
+  /**
+   * Start a task. This method handles starting a new React instance if required.
+   *
+   * <p>Has to be called on the UI thread.
+   *
+   * @param taskConfig describes what task to start and the parameters to pass to it
+   */
+  public void startTask(Context context, final TaskConfig taskConfig) throws AssertionError {
+    UiThreadUtil.assertOnUiThread();
+
+    // push this HeadlessEvent onto the taskQueue, to be drained once the React context is finished
+    // initializing,
+    // or executed immediately if Context exists currently.
+    synchronized (mTaskQueue) {
+      mTaskQueue.add(taskConfig);
+    }
+
+    if (!mIsReactContextInitialized.get()) {
+      createReactContextAndScheduleTask(context);
+    } else {
+      invokeStartTask(getReactContext(context), taskConfig);
+    }
+  }
+
+  private synchronized void invokeStartTask(
+      ReactContext reactContext, final TaskConfig taskConfig) {
+    final HeadlessJsTaskContext headlessJsTaskContext =
+        HeadlessJsTaskContext.getInstance(reactContext);
+    try {
+      if (mIsHeadlessJsTaskListenerRegistered.compareAndSet(false, true)) {
+        // Register the RN HeadlessJSTaskEventListener just once.
+        // This inline-listener is handy here as a closure around the HeadlessJsTaskContext.
+        // Otherwise, we'd have to store this Context to an instance var.
+        // The only purpose of this listener is to clear events from the queue.  The RN task is
+        // assumed to have had its .stopTask(taskId) method called, which is why this event has
+        // fired.
+        // WARNING:  this listener seems to receive events from ANY OTHER plugin's Headless events.
+        // TODO we might use a LifeCycle event-listener here to remove the listener when the app is
+        // launched to foreground.
+        headlessJsTaskContext.addTaskEventListener(
+            new HeadlessJsTaskEventListener() {
+              @Override
+              public void onHeadlessJsTaskStart(int taskId) {}
+
+              @Override
+              public void onHeadlessJsTaskFinish(int taskId) {
+                synchronized (mTaskQueue) {
+                  if (mTaskQueue.isEmpty()) {
+                    // Nothing in queue?  This event cannot be for us.
+                    return;
+                  }
+                  // Query our queue for this event...
+                  TaskConfig taskConfig = null;
+                  for (TaskConfig config : mTaskQueue) {
+                    if (config.getReactTaskId() == taskId) {
+                      taskConfig = config;
+                      break;
+                    }
+                  }
+                  if (taskConfig != null) {
+                    // Clear it from the Queue.
+                    Log.d("NotifeeHeadlessJS", "taskId: " + taskConfig.getTaskId());
+                    mTaskQueue.remove(taskConfig);
+                    if (taskConfig.getCallback() != null) {
+                      taskConfig.getCallback().call();
+                    }
+                  } else {
+                    Log.w("NotifeeHeadlessJS", "Failed to find taskId: " + taskId);
+                  }
+                }
+              }
+            });
+      }
+      // Finally:  the actual launch of the RN headless-task!
+      int taskId = headlessJsTaskContext.startTask(taskConfig.getTaskConfig());
+      // Provide the RN taskId to our private TaskConfig instance, mapping the RN taskId to our
+      // TaskConfig's internal taskId.
+      taskConfig.setReactTaskId(taskId);
+      Log.d("NotifeeHeadlessJS", "taskId: " + taskId);
+    } catch (IllegalStateException e) {
+      Log.e("NotifeeHeadlessJS", e.getMessage(), e);
+    }
+  }
+
+  public static ReactNativeHost getReactNativeHost(Context context) {
+    return ((ReactApplication) context.getApplicationContext()).getReactNativeHost();
+  }
+
+  /** Get the {ReactHost} used by this app. ure and returns null if not. */
+  public static @Nullable Object getReactHost(Context context) {
+    context = context.getApplicationContext();
+    try {
+      Method getReactHost = context.getClass().getMethod("getReactHost");
+      return getReactHost.invoke(context);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  public static ReactContext getReactContext(Context context) {
+    if (isBridgelessArchitectureEnabled()) {
+      Object reactHost = getReactHost(context);
+      Assertions.assertNotNull(reactHost, "getReactHost() is null in New Architecture");
+      try {
+        Method getCurrentReactContext = reactHost.getClass().getMethod("getCurrentReactContext");
+        return (ReactContext) getCurrentReactContext.invoke(reactHost);
+      } catch (Exception e) {
+        Log.e("NotifeeHeadlessJS", "Reflection error getCurrentReactContext: " + e.getMessage(), e);
+      }
+    }
+    final ReactInstanceManager reactInstanceManager =
+        getReactNativeHost(context).getReactInstanceManager();
+    return reactInstanceManager.getCurrentReactContext();
+  }
+
+  private void createReactContextAndScheduleTask(Context context) {
+
+    // ReactContext could have already been initialized by another plugin (eg: background-fetch).
+    // If we get a non-null ReactContext here, we're good to go!
+    ReactContext reactContext = getReactContext(context);
+    if (reactContext != null && !mIsInitializingReactContext.get()) {
+      mIsReactContextInitialized.set(true);
+      drainTaskQueue(reactContext);
+      return;
+    }
+    if (mIsInitializingReactContext.compareAndSet(false, true)) {
+      Log.d("NotifeeHeadlessJS", "initialize ReactContext");
+      final Object reactHost = getReactHost(context);
+      if (isBridgelessArchitectureEnabled()) { // NEW arch
+        ReactInstanceEventListener callback =
+            new ReactInstanceEventListener() {
+              @Override
+              public void onReactContextInitialized(@NonNull ReactContext reactContext) {
+                mIsReactContextInitialized.set(true);
+                drainTaskQueue(reactContext);
+                try {
+                  Method removeReactInstanceEventListener =
+                      reactHost
+                          .getClass()
+                          .getMethod(
+                              "removeReactInstanceEventListener", ReactInstanceEventListener.class);
+                  removeReactInstanceEventListener.invoke(reactHost, this);
+                } catch (Exception e) {
+                  Log.e("NotifeeHeadlessJS", "reflection error A: " + e, e);
+                }
+              }
+            };
+        try {
+          Method addReactInstanceEventListener =
+              reactHost
+                  .getClass()
+                  .getMethod("addReactInstanceEventListener", ReactInstanceEventListener.class);
+          addReactInstanceEventListener.invoke(reactHost, callback);
+          Method startReactHost = reactHost.getClass().getMethod("start");
+          startReactHost.invoke(reactHost);
+        } catch (Exception e) {
+          Log.e("NotifeeHeadlessJS", "reflection error ReactHost start: " + e.getMessage(), e);
+        }
+      } else { // OLD arch
+        final ReactInstanceManager reactInstanceManager =
+            getReactNativeHost(context).getReactInstanceManager();
+        reactInstanceManager.addReactInstanceEventListener(
+            new ReactInstanceEventListener() {
+              @Override
+              public void onReactContextInitialized(@NonNull ReactContext reactContext) {
+                mIsReactContextInitialized.set(true);
+                drainTaskQueue(reactContext);
+                reactInstanceManager.removeReactInstanceEventListener(this);
+              }
+            });
+        reactInstanceManager.createReactContextInBackground();
+      }
+    }
+  }
+
+  /**
+   * Invokes HeadlessEvents queued while waiting for the ReactContext to initialize.
+   *
+   * @param reactContext
+   */
+  private void drainTaskQueue(final ReactContext reactContext) {
+    new Handler(Looper.getMainLooper())
+        .postDelayed(
+            () -> {
+              synchronized (mTaskQueue) {
+                for (TaskConfig taskConfig : mTaskQueue) {
+                  invokeStartTask(reactContext, taskConfig);
+                }
+              }
+            },
+            500);
+  }
+
+  /**
+   * Return true if this app is running with RN's bridgeless architecture. Cheers to @mikehardy for
+   * this idea.
+   *
+   * @return
+   */
+  public static boolean isBridgelessArchitectureEnabled() {
+    try {
+      Class<?> entryPoint =
+          Class.forName("com.facebook.react.defaults.DefaultNewArchitectureEntryPoint");
+      Method bridgelessEnabled = entryPoint.getMethod("getBridgelessEnabled");
+      Object result = bridgelessEnabled.invoke(null);
+      return (result == Boolean.TRUE);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /** Wrapper for a client event. Inserts our custom taskId into the RN ClientEvent params. */
+  public static class TaskConfig {
+    private final String mTaskName;
+    private final long mTaskTimeout;
+    private final GenericCallback mCallback;
+    private final int mTaskId;
+    private int mReactTaskId;
+    private final WritableMap mParams;
+
+    public TaskConfig(
+        String taskName,
+        long taskTimeout,
+        WritableMap params,
+        @Nullable GenericCallback taskCompletionCallback) {
+      mTaskName = taskName;
+      mTaskTimeout = taskTimeout;
+      mCallback = taskCompletionCallback;
+      mTaskId = getNextTaskId();
+      // Insert our custom taskId for users to call finishHeadlessTask(taskId) with.
+      params.putInt("taskId", mTaskId);
+      mParams = params;
+    }
+
+    public void setReactTaskId(int taskId) {
+      mReactTaskId = taskId;
+    }
+
+    public int getTaskId() {
+      return mTaskId;
+    }
+
+    public int getReactTaskId() {
+      return mReactTaskId;
+    }
+
+    public @Nullable GenericCallback getCallback() {
+      return mCallback;
+    }
+
+    public HeadlessJsTaskConfig getTaskConfig() {
+      return new HeadlessJsTaskConfig(mTaskName, mParams, mTaskTimeout, true);
+    }
+  }
+
+  public interface GenericCallback {
+    void call();
+  }
+}

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeApiModule.java
@@ -47,7 +47,7 @@ public class NotifeeApiModule extends ReactContextBaseJavaModule implements Perm
   // It should be marked @Override but that would cause problems in apps using older react-native
   // When minimum supported version is 0.74+ add @Override & remove onCatalystInstanceDestroy
   public void invalidate() {
-    NotifeeReactUtils.clearRunningHeadlessTasks();
+    NotifeeReactUtils.headlessTaskManager.stopAllTasks();
   }
 
   @ReactMethod

--- a/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
+++ b/packages/react-native/android/src/main/java/io/invertase/notifee/NotifeeReactUtils.java
@@ -4,52 +4,28 @@
 
 package io.invertase.notifee;
 
+import static io.invertase.notifee.HeadlessTask.getReactContext;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
-import android.util.SparseArray;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import app.notifee.core.EventSubscriber;
-import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.ReactNativeHost;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.jstasks.HeadlessJsTaskConfig;
-import com.facebook.react.jstasks.HeadlessJsTaskContext;
-import com.facebook.react.jstasks.HeadlessJsTaskEventListener;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import java.lang.reflect.Method;
 import java.util.List;
 
 class NotifeeReactUtils {
-  private static final SparseArray<GenericCallback> headlessTasks = new SparseArray<>();
-  private static final HeadlessJsTaskEventListener headlessTasksListener =
-      new HeadlessJsTaskEventListener() {
-        @Override
-        public void onHeadlessJsTaskStart(int taskId) {}
-
-        @Override
-        public void onHeadlessJsTaskFinish(int taskId) {
-          synchronized (headlessTasks) {
-            GenericCallback callback = headlessTasks.get(taskId);
-            if (callback != null) {
-              headlessTasks.remove(taskId);
-              callback.call();
-            }
-          }
-        }
-      };
+  public static final HeadlessTask headlessTaskManager = new HeadlessTask();
 
   static void promiseResolver(Promise promise, Exception e, Bundle bundle) {
     if (e != null) {
@@ -106,114 +82,20 @@ class NotifeeReactUtils {
     }
   }
 
-  @SuppressLint("VisibleForTests")
-  private static @Nullable ReactContext getReactContext() {
-    try {
-
-      // Carefully try to load new architecture classes so we preserve backwards compatibility
-      // These symbols are only available in react-native >= 0.73
-      try {
-        Class<?> entryPoint =
-            Class.forName("com.facebook.react.defaults.DefaultNewArchitectureEntryPoint");
-        Method bridgelessEnabled = entryPoint.getMethod("getBridgelessEnabled");
-        Object result = bridgelessEnabled.invoke(null);
-        if (result == Boolean.TRUE) {
-          Log.d("Notifee::getReactContext", "We are in bridgeless new architecture mode");
-          Object reactApplication = EventSubscriber.getContext();
-          Method getReactHost = reactApplication.getClass().getMethod("getReactHost");
-          Object reactHostInstance = getReactHost.invoke(reactApplication);
-          Method getCurrentReactContext =
-              reactHostInstance.getClass().getMethod("getCurrentReactContext");
-          return (ReactContext) getCurrentReactContext.invoke(reactHostInstance);
-        } else {
-          Log.d("Notifee::getReactContext", "we are NOT in bridgeless new architecture mode");
-        }
-      } catch (Exception e) {
-        Log.d("Notifee::getReactContext", "New Architecture class load failed. Using fallback.");
-      }
-
-      Log.d("Notifee::getReactContext", "Determining ReactContext using fallback method");
-      ReactNativeHost reactNativeHost =
-          ((ReactApplication) EventSubscriber.getContext()).getReactNativeHost();
-      ReactInstanceManager reactInstanceManager = reactNativeHost.getReactInstanceManager();
-      return reactInstanceManager.getCurrentReactContext();
-    } catch (Exception e) {
-      Log.w("Notifee::getReactContext", "ReactHost unexpectedly null", e);
-    }
-
-    Log.w("Notifee::getReactContext", "Unable to determine ReactContext");
-    return null;
-  }
-
-  private static void initializeReactContext(GenericCallback callback) {
-    ReactNativeHost reactNativeHost =
-        ((ReactApplication) EventSubscriber.getContext()).getReactNativeHost();
-
-    ReactInstanceManager reactInstanceManager = reactNativeHost.getReactInstanceManager();
-
-    reactInstanceManager.addReactInstanceEventListener(
-        new ReactInstanceManager.ReactInstanceEventListener() {
-          @Override
-          public void onReactContextInitialized(@NonNull final ReactContext reactContext) {
-            reactInstanceManager.removeReactInstanceEventListener(this);
-            new Handler(Looper.getMainLooper()).postDelayed(callback::call, 100);
-          }
-        });
-
-    if (!reactInstanceManager.hasStartedCreatingInitialContext()) {
-      reactInstanceManager.createReactContextInBackground();
-    }
-  }
-
-  static void clearRunningHeadlessTasks() {
-    for (int i = 0; i < headlessTasks.size(); i++) {
-      GenericCallback callback = headlessTasks.valueAt(i);
-      callback.call();
-      headlessTasks.remove(i);
-    }
-  }
-
   static void startHeadlessTask(
       String taskName,
       WritableMap taskData,
       long taskTimeout,
-      @Nullable GenericCallback taskCompletionCallback) {
-    GenericCallback callback =
-        () -> {
-          HeadlessJsTaskContext taskContext = HeadlessJsTaskContext.getInstance(getReactContext());
-          HeadlessJsTaskConfig taskConfig =
-              new HeadlessJsTaskConfig(taskName, taskData, taskTimeout, true);
+      @Nullable HeadlessTask.GenericCallback taskCompletionCallback) {
 
-          synchronized (headlessTasks) {
-            if (headlessTasks.size() == 0) {
-              taskContext.addTaskEventListener(headlessTasksListener);
-            }
-          }
-
-          headlessTasks.put(
-              taskContext.startTask(taskConfig),
-              () -> {
-                synchronized (headlessTasks) {
-                  if (headlessTasks.size() == 0) {
-                    taskContext.removeTaskEventListener(headlessTasksListener);
-                  }
-                }
-                if (taskCompletionCallback != null) {
-                  taskCompletionCallback.call();
-                }
-              });
-        };
-
-    if (getReactContext() == null) {
-      initializeReactContext(callback);
-    } else {
-      callback.call();
-    }
+    HeadlessTask.TaskConfig config =
+        new HeadlessTask.TaskConfig(taskName, taskTimeout, taskData, taskCompletionCallback);
+    headlessTaskManager.startTask(EventSubscriber.getContext(), config);
   }
 
   static void sendEvent(String eventName, WritableMap eventMap) {
     try {
-      ReactContext reactContext = getReactContext();
+      ReactContext reactContext = getReactContext(EventSubscriber.getContext());
 
       if (reactContext == null || !reactContext.hasActiveCatalystInstance()) {
         return;
@@ -229,12 +111,10 @@ class NotifeeReactUtils {
   }
 
   static boolean isAppInForeground() {
-    Boolean isForeground =
-        ProcessLifecycleOwner.get()
-            .getLifecycle()
-            .getCurrentState()
-            .isAtLeast(Lifecycle.State.RESUMED);
-    return isForeground;
+    return ProcessLifecycleOwner.get()
+        .getLifecycle()
+        .getCurrentState()
+        .isAtLeast(Lifecycle.State.RESUMED);
   }
 
   static void hideNotificationDrawer() {
@@ -251,9 +131,5 @@ class NotifeeReactUtils {
     } catch (Exception e) {
       Log.e("HIDE_NOTIF_DRAWER", "", e);
     }
-  }
-
-  interface GenericCallback {
-    void call();
   }
 }

--- a/tests_react_native/example/app.tsx
+++ b/tests_react_native/example/app.tsx
@@ -24,6 +24,8 @@ import Notifee, {
   EventType,
   Event,
   AuthorizationStatus,
+  TimestampTrigger,
+  TriggerType,
   // TimestampTrigger,
   // RepeatFrequency,
 } from '@notifee/react-native';
@@ -42,6 +44,12 @@ const colors: { [key: string]: string } = {
 };
 
 const channels: AndroidChannel[] = [
+  {
+    name: 'Scheduled',
+    id: 'high',
+    importance: AndroidImportance.HIGH,
+    // sound: 'hollow',
+  },
   {
     name: 'High Importance',
     id: 'high',
@@ -152,6 +160,31 @@ function Root(): any {
     init().catch(console.error);
   }, []);
 
+  const scheduleNotification = async () => {
+    const trigger: TimestampTrigger = {
+      type: TriggerType.TIMESTAMP,
+      timestamp: new Date(Date.now() + 10000).getTime(),
+    };
+
+    try {
+      await Notifee.createTriggerNotification(
+        {
+          title: 'title',
+          body: 'body',
+          subtitle: 'subtitle',
+          id: 'notifId',
+          android: {
+            channelId: 'Scheduled',
+            badgeCount: 1,
+          },
+        },
+        trigger,
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   async function displayNotification(
     notification: Notification | Notification[],
     channelId: string,
@@ -248,6 +281,10 @@ function Root(): any {
             onPress={async (): Promise<void> => {
               console.log(await Notifee.openAlarmPermissionSettings());
             }}
+          />
+          <Button
+            title={`create trigger notification +15secs from now`}
+            onPress={async (): Promise<void> => scheduleNotification()}
           />
           <Button
             title={`Cancel all `}

--- a/tests_react_native/example/app.tsx
+++ b/tests_react_native/example/app.tsx
@@ -89,16 +89,6 @@ async function onMessage(message: RemoteMessage): Promise<void> {
   // });
 }
 
-async function onBackgroundMessage(message: RemoteMessage): Promise<void> {
-  console.log('onBackgroundMessage New FCM Message', message);
-  // await Notifee.displayNotification({
-  //   title: 'onMessage',
-  //   body: `with message ${message.messageId}`,
-  //   android: { channelId: 'default', tag: 'hello1' },
-  // });
-}
-
-firebase.messaging().setBackgroundMessageHandler(onBackgroundMessage);
 function Root(): any {
   const [id, _] = React.useState<string | null>(null);
 

--- a/tests_react_native/example/app.tsx
+++ b/tests_react_native/example/app.tsx
@@ -296,12 +296,12 @@ function Root(): any {
             }}
           />
         </View>
-        {notifications.map(({ key, notification }): any => (
-          <View key={key} style={styles.rowItem}>
+        {notifications.map(({ key, notification }, index): any => (
+          <View key={`${key}_${index}`} style={styles.rowItem}>
             <Text style={styles.header}>{key}</Text>
-            <View style={styles.row}>
-              {channels.map(channel => (
-                <View key={channel.id + key} style={styles.rowItem}>
+            <View key={`${key}_row_${index}`} style={styles.row}>
+              {channels.map((channel, subIndex) => (
+                <View key={channel.id + key + index + subIndex} style={styles.rowItem}>
                   <Button
                     title={`>.`}
                     onPress={(): any => displayNotification(notification, channel.id)}

--- a/tests_react_native/index.js
+++ b/tests_react_native/index.js
@@ -1,5 +1,10 @@
 import { AppRegistry } from 'react-native';
+import notifee from '@notifee/react-native';
 
 import App from './example/app';
+
+notifee.onBackgroundEvent(async event => {
+  console.log('notifee.onBackgroundEvent triggered: ' + JSON.stringify(event));
+});
 
 AppRegistry.registerComponent('testing', () => App);

--- a/tests_react_native/index.js
+++ b/tests_react_native/index.js
@@ -1,7 +1,13 @@
 import { AppRegistry } from 'react-native';
+import '@react-native-firebase/messaging';
+import firebase from '@react-native-firebase/app';
 import notifee from '@notifee/react-native';
 
 import App from './example/app';
+
+firebase.messaging().setBackgroundMessageHandler(async message => {
+  console.log('onBackgroundMessage New FCM Message', message);
+});
 
 notifee.onBackgroundEvent(async event => {
   console.log('notifee.onBackgroundEvent triggered: ' + JSON.stringify(event));

--- a/tests_react_native/ios/Podfile.lock
+++ b/tests_react_native/ios/Podfile.lock
@@ -351,10 +351,10 @@ PODS:
     - Firebase/Messaging (= 8.15.0)
     - React-Core
     - RNFBApp
-  - RNNotifee (9.0.2):
+  - RNNotifee (9.1.3):
     - NotifeeCore
     - React-Core
-  - RNNotifeeCore (9.0.2):
+  - RNNotifeeCore (9.1.3):
     - NotifeeCore
   - Yoga (1.14.0)
 
@@ -493,7 +493,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CavyNativeReporter: 22479f189ecd26513573801d005244bd47abb188
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 6fab494fa11340bd4206edaebed07279a6bafad4
   FBReactNativeSpec: 76d7b03876b0ad0b86bc5c84d23af8e64db8e096
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
@@ -502,13 +502,13 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   NotifeeCore: 7163fe1ba23401a81430438a037a40a00221b80e
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: b9e53f0512019150020156fa0dacd6583ab838be
   RCTTypeSafety: 04b72202bef8302802610dee70bb9407a245b64c
   React: 59288a7ca8104eb8002f01378606fe42eeabf4b5
@@ -536,10 +536,10 @@ SPEC CHECKSUMS:
   ReactCommon: f4bb9e5209ea5c3c6ab25e100895119e58d6e50a
   RNFBApp: e4439717c23252458da2b41b81b4b475c86f90c4
   RNFBMessaging: 40dac204b4197a2661dec5be964780c6ec39bf65
-  RNNotifee: 369bc03ba4785001e1c08bc8185ea82278bdb05a
-  RNNotifeeCore: f45f9d46428bf085201a3d7c0988a7abca3967c2
+  RNNotifee: bf411d40a326c91c476ba2d6f2fcacb8edde54c5
+  RNNotifeeCore: 790050ccb546268347885732669745b3aa6e176c
   Yoga: 8a90b50af67eaa9fe94fd03e550bfeab06096873
 
 PODFILE CHECKSUM: 0a7cc0c2dfdaa228004324b420c9bdc099bdf0b4
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
very tricky to make sure react-native is initialized during headlessJS startup so you don't beat it in the race to asking for a ReactContext before it exists

- startup is event-driven so you have to attach listeners
- startup has to run on main thread so you have to post runnables
- multiple tasks may come in while starting up, you must queue / drain
- startup objects / methods differ across react-native new / old arch

get all that right, and you'll have a valid ReactContext, without dropping any tasks that needed it before react-native was initialized

Previously, we were attempting to use a null ReactContext, resulting in errors from upstream headless services complaining about the context already being destroyed

Fixes #266 