### PR TITLE
docs: use typedoc+markdown plugin for docs.page compatible reference

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -33,7 +33,7 @@
       "@semantic-release/git",
       {
         "assets": [
-          "docs/react-native/release-notes.mdx",
+          "docs/react-native/",
           "packages/react-native/package.json",
           "packages/react-native/android/libs"
         ],

--- a/docs.json
+++ b/docs.json
@@ -29,6 +29,10 @@
         {
           "title": "Release Notes",
           "href": "/react-native/release-notes"
+        },
+        {
+          "title": "API Reference",
+          "href": "/react-native/reference"
         }
       ]
     },

--- a/docs/react-native/reference/Enumeration.AlarmType.mdx
+++ b/docs/react-native/reference/Enumeration.AlarmType.mdx
@@ -8,7 +8,7 @@
 
 An interface representing the different alarm types which can be used with `TimestampTrigger.alarmManager.type`.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+View the [Triggers](/react-native/triggers) documentation to learn more.
 
 ## Enumeration Members
 

--- a/docs/react-native/reference/Enumeration.AlarmType.mdx
+++ b/docs/react-native/reference/Enumeration.AlarmType.mdx
@@ -1,0 +1,61 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AlarmType
+
+# Enumeration: AlarmType
+
+An interface representing the different alarm types which can be used with `TimestampTrigger.alarmManager.type`.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+
+## Enumeration Members
+
+### SET
+
+> **SET**: `0`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:43](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L43)
+
+***
+
+### SET\_ALARM\_CLOCK
+
+> **SET\_ALARM\_CLOCK**: `4`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:47](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L47)
+
+***
+
+### SET\_AND\_ALLOW\_WHILE\_IDLE
+
+> **SET\_AND\_ALLOW\_WHILE\_IDLE**: `1`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:44](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L44)
+
+***
+
+### SET\_EXACT
+
+> **SET\_EXACT**: `2`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:45](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L45)
+
+***
+
+### SET\_EXACT\_AND\_ALLOW\_WHILE\_IDLE
+
+> **SET\_EXACT\_AND\_ALLOW\_WHILE\_IDLE**: `3`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:46](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L46)

--- a/docs/react-native/reference/Enumeration.AndroidBadgeIconType.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidBadgeIconType.mdx
@@ -1,0 +1,53 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidBadgeIconType
+
+# Enumeration: AndroidBadgeIconType
+
+Enum used to define how a notification badge is displayed in badge mode.
+
+View the [Badges](/react-native/docs/android/appearance#badges) documentation for more information.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### LARGE
+
+> **LARGE**: `2`
+
+Shows the badge as the notifications `largeIcon` (if available).
+
+This is the default value used by a notification if not provided.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1092](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1092)
+
+***
+
+### NONE
+
+> **NONE**: `0`
+
+No badge is displayed, will always show as a number.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1080](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1080)
+
+***
+
+### SMALL
+
+> **SMALL**: `1`
+
+Shows the badge as the notifications `smallIcon`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1085](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1085)

--- a/docs/react-native/reference/Enumeration.AndroidBadgeIconType.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidBadgeIconType.mdx
@@ -8,7 +8,7 @@
 
 Enum used to define how a notification badge is displayed in badge mode.
 
-View the [Badges](/react-native/docs/android/appearance#badges) documentation for more information.
+View the [Badges](/react-native/android/appearance#badges) documentation for more information.
 
 ## Platform
 

--- a/docs/react-native/reference/Enumeration.AndroidCategory.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidCategory.mdx
@@ -1,0 +1,179 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidCategory
+
+# Enumeration: AndroidCategory
+
+Enum used to describe the category of a notification.
+
+Setting a category on a notification helps the device to understand what the notification is for,
+or what impact it will have on the user. The category can be used for ranking and filtering
+the notification, however has no visual impact on the notification.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### ALARM
+
+> **ALARM**: `"alarm"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1105](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1105)
+
+***
+
+### CALL
+
+> **CALL**: `"call"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1106](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1106)
+
+***
+
+### EMAIL
+
+> **EMAIL**: `"email"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1107](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1107)
+
+***
+
+### ERROR
+
+> **ERROR**: `"error"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1108](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1108)
+
+***
+
+### EVENT
+
+> **EVENT**: `"event"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1109](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1109)
+
+***
+
+### MESSAGE
+
+> **MESSAGE**: `"msg"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1110](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1110)
+
+***
+
+### NAVIGATION
+
+> **NAVIGATION**: `"navigation"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1111](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1111)
+
+***
+
+### PROGRESS
+
+> **PROGRESS**: `"progress"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1112](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1112)
+
+***
+
+### PROMO
+
+> **PROMO**: `"promo"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1113](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1113)
+
+***
+
+### RECOMMENDATION
+
+> **RECOMMENDATION**: `"recommendation"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1114](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1114)
+
+***
+
+### REMINDER
+
+> **REMINDER**: `"reminder"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1115](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1115)
+
+***
+
+### SERVICE
+
+> **SERVICE**: `"service"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1116](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1116)
+
+***
+
+### SOCIAL
+
+> **SOCIAL**: `"social"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1117](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1117)
+
+***
+
+### STATUS
+
+> **STATUS**: `"status"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1118](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1118)
+
+***
+
+### SYSTEM
+
+> **SYSTEM**: `"sys"`
+
+Avoid using - generally used by the system.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1123](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1123)
+
+***
+
+### TRANSPORT
+
+> **TRANSPORT**: `"transport"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1124](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1124)

--- a/docs/react-native/reference/Enumeration.AndroidColor.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidColor.mdx
@@ -1,0 +1,235 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidColor
+
+# Enumeration: AndroidColor
+
+A set or predefined colors which can be used with Android Notifications.
+
+View the [Color](/react-native/docs/android/appearance#color) documentation to learn more.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### AQUA
+
+> **AQUA**: `"aqua"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1148](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1148)
+
+***
+
+### BLACK
+
+> **BLACK**: `"black"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1138](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1138)
+
+***
+
+### BLUE
+
+> **BLUE**: `"blue"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1136](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1136)
+
+***
+
+### CYAN
+
+> **CYAN**: `"cyan"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1140](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1140)
+
+***
+
+### DARKGRAY
+
+> **DARKGRAY**: `"darkgray"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1144](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1144)
+
+***
+
+### DARKGREY
+
+> **DARKGREY**: `"darkgrey"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1147](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1147)
+
+***
+
+### FUCHSIA
+
+> **FUCHSIA**: `"fuchsia"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1149](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1149)
+
+***
+
+### GRAY
+
+> **GRAY**: `"gray"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1145](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1145)
+
+***
+
+### GREEN
+
+> **GREEN**: `"green"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1137](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1137)
+
+***
+
+### LIGHTGRAY
+
+> **LIGHTGRAY**: `"lightgray"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1143](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1143)
+
+***
+
+### LIGHTGREY
+
+> **LIGHTGREY**: `"lightgrey"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1146](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1146)
+
+***
+
+### LIME
+
+> **LIME**: `"lime"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1150](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1150)
+
+***
+
+### MAGENTA
+
+> **MAGENTA**: `"magenta"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1141](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1141)
+
+***
+
+### MAROON
+
+> **MAROON**: `"maroon"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1151](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1151)
+
+***
+
+### NAVY
+
+> **NAVY**: `"navy"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1152](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1152)
+
+***
+
+### OLIVE
+
+> **OLIVE**: `"olive"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1153](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1153)
+
+***
+
+### PURPLE
+
+> **PURPLE**: `"purple"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1154](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1154)
+
+***
+
+### RED
+
+> **RED**: `"red"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1135](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1135)
+
+***
+
+### SILVER
+
+> **SILVER**: `"silver"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1155](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1155)
+
+***
+
+### TEAL
+
+> **TEAL**: `"teal"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1156](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1156)
+
+***
+
+### WHITE
+
+> **WHITE**: `"white"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1139](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1139)
+
+***
+
+### YELLOW
+
+> **YELLOW**: `"yellow"`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1142](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1142)

--- a/docs/react-native/reference/Enumeration.AndroidColor.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidColor.mdx
@@ -8,7 +8,7 @@
 
 A set or predefined colors which can be used with Android Notifications.
 
-View the [Color](/react-native/docs/android/appearance#color) documentation to learn more.
+View the [Color](/react-native/android/appearance#color) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Enumeration.AndroidDefaults.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidDefaults.mdx
@@ -1,0 +1,66 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidDefaults
+
+# Enumeration: AndroidDefaults
+
+On devices which do not support notification channels (API Level \< 26), the notification
+by default will use all methods to alert the user (depending on the importance).
+
+To override the default behaviour, provide an array of defaults to the notification.
+
+On API Levels >= 26, this has no effect and notifications will use the channel behaviour.
+
+## Platform
+
+android API Level \< 26
+
+## Enumeration Members
+
+### ALL
+
+> **ALL**: `-1`
+
+All options will be used, where possible.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1173](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1173)
+
+***
+
+### LIGHTS
+
+> **LIGHTS**: `4`
+
+The notification will use lights to alert the user.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1178](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1178)
+
+***
+
+### SOUND
+
+> **SOUND**: `1`
+
+The notification will use sound to alert the user.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1183](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1183)
+
+***
+
+### VIBRATE
+
+> **VIBRATE**: `2`
+
+The notification will vibrate to alert the user.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1188](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1188)

--- a/docs/react-native/reference/Enumeration.AndroidFlags.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidFlags.mdx
@@ -1,0 +1,36 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidFlags
+
+# Enumeration: AndroidFlags
+
+Enum used to set any additional flags supported on Android.
+See Android's [setFlag()](https://developer.android.com/reference/android/app/Notification.Builder#setFlag\(int,%20boolean\)) documentation.
+
+## Enumeration Members
+
+### FLAG\_INSISTENT
+
+> **FLAG\_INSISTENT**: `4`
+
+The audio will be repeated until the notification is cancelled or the notification window is opened.
+This will be set for you by setting `loopSound`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1200](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1200)
+
+***
+
+### FLAG\_NO\_CLEAR
+
+> **FLAG\_NO\_CLEAR**: `32`
+
+Prevents the notification from being canceled when the user clicks the Clear all button.
+This will be set for you by setting `ongoing`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1206](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1206)

--- a/docs/react-native/reference/Enumeration.AndroidForegroundServiceType.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidForegroundServiceType.mdx
@@ -1,0 +1,164 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidForegroundServiceType
+
+# Enumeration: AndroidForegroundServiceType
+
+Enum used to set the foreground service types identifying the work done by the service.
+See Android's [foreground service types](https://developer.android.com/develop/background-work/services/fg-service-types) documentation.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### FOREGROUND\_SERVICE\_TYPE\_CAMERA
+
+> **FOREGROUND\_SERVICE\_TYPE\_CAMERA**: `64`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1463](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1463)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_CONNECTED\_DEVICE
+
+> **FOREGROUND\_SERVICE\_TYPE\_CONNECTED\_DEVICE**: `16`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1464](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1464)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_DATA\_SYNC
+
+> **FOREGROUND\_SERVICE\_TYPE\_DATA\_SYNC**: `1`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1465](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1465)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_HEALTH
+
+> **FOREGROUND\_SERVICE\_TYPE\_HEALTH**: `256`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1466](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1466)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_LOCATION
+
+> **FOREGROUND\_SERVICE\_TYPE\_LOCATION**: `8`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1467](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1467)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_MANIFEST
+
+> **FOREGROUND\_SERVICE\_TYPE\_MANIFEST**: `-1`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1477](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1477)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_MEDIA\_PLAYBACK
+
+> **FOREGROUND\_SERVICE\_TYPE\_MEDIA\_PLAYBACK**: `2`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1468](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1468)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_MEDIA\_PROCESSING
+
+> **FOREGROUND\_SERVICE\_TYPE\_MEDIA\_PROCESSING**: `8192`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1470](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1470)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_MEDIA\_PROJECTION
+
+> **FOREGROUND\_SERVICE\_TYPE\_MEDIA\_PROJECTION**: `32`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1469](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1469)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_MICROPHONE
+
+> **FOREGROUND\_SERVICE\_TYPE\_MICROPHONE**: `128`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1471](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1471)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_PHONE\_CALL
+
+> **FOREGROUND\_SERVICE\_TYPE\_PHONE\_CALL**: `4`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1472](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1472)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_REMOTE\_MESSAGING
+
+> **FOREGROUND\_SERVICE\_TYPE\_REMOTE\_MESSAGING**: `512`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1473](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1473)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_SHORT\_SERVICE
+
+> **FOREGROUND\_SERVICE\_TYPE\_SHORT\_SERVICE**: `2048`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1474](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1474)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_SPECIAL\_USE
+
+> **FOREGROUND\_SERVICE\_TYPE\_SPECIAL\_USE**: `1073741824`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1475](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1475)
+
+***
+
+### FOREGROUND\_SERVICE\_TYPE\_SYSTEM\_EXEMPTED
+
+> **FOREGROUND\_SERVICE\_TYPE\_SYSTEM\_EXEMPTED**: `1024`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1476](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1476)

--- a/docs/react-native/reference/Enumeration.AndroidGroupAlertBehavior.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidGroupAlertBehavior.mdx
@@ -1,0 +1,52 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidGroupAlertBehavior
+
+# Enumeration: AndroidGroupAlertBehavior
+
+Enum used to describe how a notification alerts the user when it apart of a group.
+
+View the [Grouping & Sorting](/react-native/docs/android/grouping-and-sorting#group-behaviour) documentation to
+learn more.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### ALL
+
+> **ALL**: `0`
+
+All notifications will alert.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1221](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1221)
+
+***
+
+### CHILDREN
+
+> **CHILDREN**: `2`
+
+Children of a group will alert the user. The summary notification will not alert when displayed.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1231](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1231)
+
+***
+
+### SUMMARY
+
+> **SUMMARY**: `1`
+
+Only the summary notification will alert the user when displayed. The children of the group will not alert.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1226](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1226)

--- a/docs/react-native/reference/Enumeration.AndroidGroupAlertBehavior.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidGroupAlertBehavior.mdx
@@ -8,7 +8,7 @@
 
 Enum used to describe how a notification alerts the user when it apart of a group.
 
-View the [Grouping & Sorting](/react-native/docs/android/grouping-and-sorting#group-behaviour) documentation to
+View the [Grouping & Sorting](/react-native/android/grouping-and-sorting#group-behaviour) documentation to
 learn more.
 
 ## Platform

--- a/docs/react-native/reference/Enumeration.AndroidImportance.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidImportance.mdx
@@ -1,0 +1,103 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidImportance
+
+# Enumeration: AndroidImportance
+
+The interface describing the importance levels of an incoming notification.
+
+The importance level can be set directly onto a notification channel for supported devices (API Level >= 26)
+or directly onto the notification for devices which do not support channels.
+
+The importance is used to both change the visual prompt of a received notification
+and also how it visually appears on the device.
+
+View the [Android Appearance](/react-native/docs/android/appearance#importance) documentation to learn more.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### DEFAULT
+
+> **DEFAULT**: `3`
+
+The default importance applied to a channel/notification.
+
+The application small icon will show in the device statusbar. When the user pulls down the
+notification shade, the notification will show in it's expanded state (if applicable).
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1298](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1298)
+
+***
+
+### HIGH
+
+> **HIGH**: `4`
+
+The highest importance level applied to a channel/notification.
+
+The notifications will appear on-top of applications, allowing direct interaction without pulling
+down the notification shade. This level should only be used for urgent notifications, such as
+incoming phone calls, messages etc, which require immediate attention.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1307](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1307)
+
+***
+
+### LOW
+
+> **LOW**: `2`
+
+A low importance level applied to a channel/notification.
+
+On Android, the application small icon will show in the device statusbar, however the notification will not alert
+the user (no sound or vibration). The notification will show in it's expanded state when the
+notification shade is pulled down.
+
+On iOS, the notification will not display to the user or alert them. It will still be visible on the devices
+notification center.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1319](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1319)
+
+***
+
+### MIN
+
+> **MIN**: `1`
+
+The minimum importance level applied to a channel/notification.
+
+The application small icon will not show up in the statusbar, or alert the user. The notification
+will be in a collapsed state in the notification shade and placed at the bottom of the list.
+
+This level should be used when the notification requires no immediate attention. An example of this
+importance level is the Google app providing weather updates and only being visible when the
+user pulls the notification shade down,
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1331](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1331)
+
+***
+
+### NONE
+
+> **NONE**: `0`
+
+The notification will not be shown. This has the same effect as the user disabling notifications
+in the application settings.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1337](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1337)

--- a/docs/react-native/reference/Enumeration.AndroidImportance.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidImportance.mdx
@@ -14,7 +14,7 @@ or directly onto the notification for devices which do not support channels.
 The importance is used to both change the visual prompt of a received notification
 and also how it visually appears on the device.
 
-View the [Android Appearance](/react-native/docs/android/appearance#importance) documentation to learn more.
+View the [Android Appearance](/react-native/android/appearance#importance) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Enumeration.AndroidLaunchActivityFlag.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidLaunchActivityFlag.mdx
@@ -1,0 +1,269 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidLaunchActivityFlag
+
+# Enumeration: AndroidLaunchActivityFlag
+
+An enum representing the various flags that can be passed along to `launchActivityFlags` on `NotificationPressAction`.
+
+These flags are added to the Android [Intent](https://developer.android.com/reference/android/content/Intent.html) that launches your activity.
+
+These are only required if you need to customise the behaviour of your activities, in most cases you might not need these.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### BROUGHT\_TO\_FRONT
+
+> **BROUGHT\_TO\_FRONT**: `8`
+
+See [FLAG\_ACTIVITY\_BROUGHT\_TO\_FRONT](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_BROUGHT_TO_FRONT) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1393](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1393)
+
+***
+
+### CLEAR\_TASK
+
+> **CLEAR\_TASK**: `16`
+
+See [FLAG\_ACTIVITY\_CLEAR\_TASK](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_TASK) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1433](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1433)
+
+***
+
+### CLEAR\_TOP
+
+> **CLEAR\_TOP**: `4`
+
+See [FLAG\_ACTIVITY\_CLEAR\_TOP](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_TOP) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1373](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1373)
+
+***
+
+### CLEAR\_WHEN\_TASK\_RESET
+
+> **CLEAR\_WHEN\_TASK\_RESET**: `11`
+
+See [FLAG\_ACTIVITY\_CLEAR\_WHEN\_TASK\_RESET](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1408](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1408)
+
+***
+
+### EXCLUDE\_FROM\_RECENTS
+
+> **EXCLUDE\_FROM\_RECENTS**: `7`
+
+See [FLAG\_ACTIVITY\_EXCLUDE\_FROM\_RECENTS](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1388](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1388)
+
+***
+
+### FORWARD\_RESULT
+
+> **FORWARD\_RESULT**: `5`
+
+See [FLAG\_ACTIVITY\_FORWARD\_RESULT](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_FORWARD_RESULT) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1378](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1378)
+
+***
+
+### LAUNCH\_ADJACENT
+
+> **LAUNCH\_ADJACENT**: `19`
+
+See [FLAG\_ACTIVITY\_LAUNCH\_ADJACENT](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_LAUNCH_ADJACENT) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1448](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1448)
+
+***
+
+### LAUNCHED\_FROM\_HISTORY
+
+> **LAUNCHED\_FROM\_HISTORY**: `10`
+
+See [FLAG\_ACTIVITY\_LAUNCHED\_FROM\_HISTORY](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1403](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1403)
+
+***
+
+### MATCH\_EXTERNAL
+
+> **MATCH\_EXTERNAL**: `20`
+
+See [FLAG\_ACTIVITY\_MATCH\_EXTERNAL](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_MATCH_EXTERNAL) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1453](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1453)
+
+***
+
+### MULTIPLE\_TASK
+
+> **MULTIPLE\_TASK**: `3`
+
+See [FLAG\_ACTIVITY\_MULTIPLE\_TASK](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_MULTIPLE_TASK) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1368](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1368)
+
+***
+
+### NEW\_DOCUMENT
+
+> **NEW\_DOCUMENT**: `12`
+
+See [FLAG\_ACTIVITY\_NEW\_DOCUMENT](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NEW_DOCUMENT) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1413](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1413)
+
+***
+
+### NEW\_TASK
+
+> **NEW\_TASK**: `2`
+
+See [FLAG\_ACTIVITY\_NEW\_TASK](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NEW_TASK) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1363](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1363)
+
+***
+
+### NO\_ANIMATION
+
+> **NO\_ANIMATION**: `15`
+
+See [FLAG\_ACTIVITY\_NO\_ANIMATION](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NO_ANIMATION) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1428](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1428)
+
+***
+
+### NO\_HISTORY
+
+> **NO\_HISTORY**: `0`
+
+See [FLAG\_ACTIVITY\_NO\_HISTORY](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NO_HISTORY) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1353](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1353)
+
+***
+
+### NO\_USER\_ACTION
+
+> **NO\_USER\_ACTION**: `13`
+
+See [FLAG\_ACTIVITY\_NO\_USER\_ACTION](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NO_USER_ACTION) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1418](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1418)
+
+***
+
+### PREVIOUS\_IS\_TOP
+
+> **PREVIOUS\_IS\_TOP**: `6`
+
+See [FLAG\_ACTIVITY\_PREVIOUS\_IS\_TOP](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_PREVIOUS_IS_TOP) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1383](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1383)
+
+***
+
+### REORDER\_TO\_FRONT
+
+> **REORDER\_TO\_FRONT**: `14`
+
+See [FLAG\_ACTIVITY\_REORDER\_TO\_FRONT](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_REORDER_TO_FRONT) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1423](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1423)
+
+***
+
+### RESET\_TASK\_IF\_NEEDED
+
+> **RESET\_TASK\_IF\_NEEDED**: `9`
+
+See [FLAG\_ACTIVITY\_RESET\_TASK\_IF\_NEEDED](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_RESET_TASK_IF_NEEDED) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1398](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1398)
+
+***
+
+### RETAIN\_IN\_RECENTS
+
+> **RETAIN\_IN\_RECENTS**: `18`
+
+See [FLAG\_ACTIVITY\_RETAIN\_IN\_RECENTS](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_RETAIN_IN_RECENTS) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1443](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1443)
+
+***
+
+### SINGLE\_TOP
+
+> **SINGLE\_TOP**: `1`
+
+See [FLAG\_ACTIVITY\_SINGLE\_TOP](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_SINGLE_TOP) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1358](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1358)
+
+***
+
+### TASK\_ON\_HOME
+
+> **TASK\_ON\_HOME**: `17`
+
+See [FLAG\_ACTIVITY\_TASK\_ON\_HOME](https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_TASK_ON_HOME) on the official Android documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1438](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1438)

--- a/docs/react-native/reference/Enumeration.AndroidNotificationSetting.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidNotificationSetting.mdx
@@ -11,7 +11,7 @@ An interface representing the current android only notification-related settings
 This interface is returned from [`requestPermission`](/react-native/reference/requestpermission)
 and [`getNotificationSettings`](/react-native/reference/getnotificationsettings).
 
-View the [Permissions](/react-native/docs/android/permissions) documentation to learn more.
+View the [Permissions](/react-native/android/permissions) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Enumeration.AndroidNotificationSetting.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidNotificationSetting.mdx
@@ -1,0 +1,55 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidNotificationSetting
+
+# Enumeration: AndroidNotificationSetting
+
+An interface representing the current android only notification-related settings for your app.
+
+This interface is returned from [`requestPermission`](/react-native/reference/requestpermission)
+and [`getNotificationSettings`](/react-native/reference/getnotificationsettings).
+
+View the [Permissions](/react-native/docs/android/permissions) documentation to learn more.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### DISABLED
+
+> **DISABLED**: `0`
+
+This setting is currently disabled by the user.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:466](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L466)
+
+***
+
+### ENABLED
+
+> **ENABLED**: `1`
+
+This setting is currently enabled.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:471](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L471)
+
+***
+
+### NOT\_SUPPORTED
+
+> **NOT\_SUPPORTED**: `-1`
+
+This setting is not supported on this device. Usually this means that the Android version required
+for this setting has not been met.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:461](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L461)

--- a/docs/react-native/reference/Enumeration.AndroidStyle.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidStyle.mdx
@@ -8,7 +8,7 @@
 
 Available Android Notification Styles.
 
-View the [Styles](/react-native/docs/android/styles) documentation to learn more with example usage.
+View the [Styles](/react-native/android/styles) documentation to learn more with example usage.
 
 ## Platform
 

--- a/docs/react-native/reference/Enumeration.AndroidStyle.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidStyle.mdx
@@ -1,0 +1,55 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidStyle
+
+# Enumeration: AndroidStyle
+
+Available Android Notification Styles.
+
+View the [Styles](/react-native/docs/android/styles) documentation to learn more with example usage.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### BIGPICTURE
+
+> **BIGPICTURE**: `0`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1242](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1242)
+
+***
+
+### BIGTEXT
+
+> **BIGTEXT**: `1`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1243](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1243)
+
+***
+
+### INBOX
+
+> **INBOX**: `2`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1244](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1244)
+
+***
+
+### MESSAGING
+
+> **MESSAGING**: `3`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1245](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1245)

--- a/docs/react-native/reference/Enumeration.AndroidVisibility.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidVisibility.mdx
@@ -1,0 +1,57 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidVisibility
+
+# Enumeration: AndroidVisibility
+
+Interface used to define the visibility of an Android notification.
+
+Use with the `visibility` property on the notification.
+
+View the [Visibility](/react-native/docs/android/appearance#visibility) documentation to learn more.
+
+Default value is `AndroidVisibility.PRIVATE`.
+
+## Platform
+
+android
+
+## Enumeration Members
+
+### PRIVATE
+
+> **PRIVATE**: `0`
+
+Show the notification on all lockscreens, but conceal sensitive or private information on secure lockscreens.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1263](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1263)
+
+***
+
+### PUBLIC
+
+> **PUBLIC**: `1`
+
+Show this notification in its entirety on all lockscreens.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1268](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1268)
+
+***
+
+### SECRET
+
+> **SECRET**: `-1`
+
+Do not reveal any part of this notification on a secure lockscreen.
+
+Useful for notifications showing sensitive information such as banking apps.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1275](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1275)

--- a/docs/react-native/reference/Enumeration.AndroidVisibility.mdx
+++ b/docs/react-native/reference/Enumeration.AndroidVisibility.mdx
@@ -10,7 +10,7 @@ Interface used to define the visibility of an Android notification.
 
 Use with the `visibility` property on the notification.
 
-View the [Visibility](/react-native/docs/android/appearance#visibility) documentation to learn more.
+View the [Visibility](/react-native/android/appearance#visibility) documentation to learn more.
 
 Default value is `AndroidVisibility.PRIVATE`.
 

--- a/docs/react-native/reference/Enumeration.AuthorizationStatus.mdx
+++ b/docs/react-native/reference/Enumeration.AuthorizationStatus.mdx
@@ -1,0 +1,69 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AuthorizationStatus
+
+# Enumeration: AuthorizationStatus
+
+An enum representing the notification authorization status for this app on the device.
+
+Value is greater than 0 if authorized, compare against an exact status (e.g. PROVISIONAL) for a more
+granular status.
+
+## Enumeration Members
+
+### AUTHORIZED
+
+> **AUTHORIZED**: `1`
+
+The app is authorized to create notifications.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:488](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L488)
+
+***
+
+### DENIED
+
+> **DENIED**: `0`
+
+The app is not authorized to create notifications.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:483](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L483)
+
+***
+
+### NOT\_DETERMINED
+
+> **NOT\_DETERMINED**: `-1`
+
+The app user has not yet chosen whether to allow the application to create notifications. Usually
+this status is returned prior to the first call of `requestPermission`.
+
+#### Platform
+
+ios
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:478](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L478)
+
+***
+
+### PROVISIONAL
+
+> **PROVISIONAL**: `2`
+
+The app is currently authorized to post non-interrupting user notifications
+
+#### Platform
+
+ios iOS >= 12
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:494](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L494)

--- a/docs/react-native/reference/Enumeration.EventType.mdx
+++ b/docs/react-native/reference/Enumeration.EventType.mdx
@@ -8,7 +8,7 @@
 
 An enum representing an event type, defined on [`Event`](/react-native/reference/event).
 
-View the [Events](/react-native/docs/events) documentation to learn more about foreground and
+View the [Events](/react-native/events) documentation to learn more about foreground and
 background events.
 
 ## Enumeration Members

--- a/docs/react-native/reference/Enumeration.EventType.mdx
+++ b/docs/react-native/reference/Enumeration.EventType.mdx
@@ -1,0 +1,163 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / EventType
+
+# Enumeration: EventType
+
+An enum representing an event type, defined on [`Event`](/react-native/reference/event).
+
+View the [Events](/react-native/docs/events) documentation to learn more about foreground and
+background events.
+
+## Enumeration Members
+
+### ACTION\_PRESS
+
+> **ACTION\_PRESS**: `2`
+
+Event type is sent when a user presses a notification action.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:341](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L341)
+
+***
+
+### APP\_BLOCKED
+
+> **APP\_BLOCKED**: `4`
+
+Event is sent when the user changes the notification blocked state for the entire application or
+when the user opens the application settings.
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:358](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L358)
+
+***
+
+### CHANNEL\_BLOCKED
+
+> **CHANNEL\_BLOCKED**: `5`
+
+Event type is sent when the user changes the notification blocked state for a channel in the application.
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:365](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L365)
+
+***
+
+### CHANNEL\_GROUP\_BLOCKED
+
+> **CHANNEL\_GROUP\_BLOCKED**: `6`
+
+Event type is sent when the user changes the notification blocked state for a channel group in the application.
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:372](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L372)
+
+***
+
+### DELIVERED
+
+> **DELIVERED**: `3`
+
+Event type sent when a notification has been delivered to the device. For trigger notifications,
+this event is sent at the point when the trigger executes, not when a the trigger notification is created.
+
+It's important to note even though a notification has been delivered, it may not be shown to the
+user. For example, they may have notifications disabled on the device/channel/app.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:350](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L350)
+
+***
+
+### DISMISSED
+
+> **DISMISSED**: `0`
+
+Event type is sent when the user dismisses a notification. This is triggered via the user swiping
+the notification from the notification shade.
+
+On Android, the event is also sent when performing "Clear all" notifications unlike on iOS.
+
+This event is **not** sent when a notification is cancelled or times out.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:327](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L327)
+
+***
+
+### FG\_ALREADY\_EXIST
+
+> **FG\_ALREADY\_EXIST**: `8`
+
+**ANDROID ONLY**
+
+Event type is sent when a notification wants to start a foreground service but a foreground service is already started.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:384](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L384)
+
+***
+
+### PRESS
+
+> **PRESS**: `1`
+
+Event type is sent when a notification has been pressed by the user.
+
+On Android, notifications must include an `android.pressAction` property for this event to trigger.
+
+On iOS, this event is always sent when the user presses a notification.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:336](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L336)
+
+***
+
+### TRIGGER\_NOTIFICATION\_CREATED
+
+> **TRIGGER\_NOTIFICATION\_CREATED**: `7`
+
+Event type is sent when a notification trigger is created.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:377](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L377)
+
+***
+
+### UNKNOWN
+
+> **UNKNOWN**: `-1`
+
+An unknown event was received.
+
+This event type is a failsafe to catch any unknown events from the device. Please
+report an issue with a reproduction so it can be correctly handled.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:317](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L317)

--- a/docs/react-native/reference/Enumeration.IOSIntentIdentifier.mdx
+++ b/docs/react-native/reference/Enumeration.IOSIntentIdentifier.mdx
@@ -1,0 +1,263 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSIntentIdentifier
+
+# Enumeration: IOSIntentIdentifier
+
+TODO docs, used to provide context to Siri
+
+## Platform
+
+ios
+
+## Enumeration Members
+
+### CANCEL\_WORKOUT
+
+> **CANCEL\_WORKOUT**: `12`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:434](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L434)
+
+***
+
+### END\_WORKOUT
+
+> **END\_WORKOUT**: `11`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:432](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L432)
+
+***
+
+### GET\_RIDE\_STATUS
+
+> **GET\_RIDE\_STATUS**: `24`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:458](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L458)
+
+***
+
+### LIST\_RIDE\_OPTIONS
+
+> **LIST\_RIDE\_OPTIONS**: `22`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:454](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L454)
+
+***
+
+### PAUSE\_WORKOUT
+
+> **PAUSE\_WORKOUT**: `10`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:430](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L430)
+
+***
+
+### REQUEST\_PAYMENT
+
+> **REQUEST\_PAYMENT**: `19`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:448](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L448)
+
+***
+
+### REQUEST\_RIDE
+
+> **REQUEST\_RIDE**: `23`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:456](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L456)
+
+***
+
+### RESUME\_WORKOUT
+
+> **RESUME\_WORKOUT**: `13`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:436](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L436)
+
+***
+
+### SAVE\_PROFILE\_IN\_CAR
+
+> **SAVE\_PROFILE\_IN\_CAR**: `8`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:426](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L426)
+
+***
+
+### SEARCH\_CALL\_HISTORY
+
+> **SEARCH\_CALL\_HISTORY**: `2`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:414](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L414)
+
+***
+
+### SEARCH\_FOR\_MESSAGES
+
+> **SEARCH\_FOR\_MESSAGES**: `16`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:442](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L442)
+
+***
+
+### SEARCH\_FOR\_PHOTOS
+
+> **SEARCH\_FOR\_PHOTOS**: `20`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:450](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L450)
+
+***
+
+### SEND\_MESSAGE
+
+> **SEND\_MESSAGE**: `15`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:440](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L440)
+
+***
+
+### SEND\_PAYMENT
+
+> **SEND\_PAYMENT**: `18`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:446](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L446)
+
+***
+
+### SET\_AUDIO\_SOURCE\_IN\_CAR
+
+> **SET\_AUDIO\_SOURCE\_IN\_CAR**: `3`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:416](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L416)
+
+***
+
+### SET\_CLIMATE\_SETTINGS\_IN\_CAR
+
+> **SET\_CLIMATE\_SETTINGS\_IN\_CAR**: `4`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:418](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L418)
+
+***
+
+### SET\_DEFROSTER\_SETTINGS\_IN\_CAR
+
+> **SET\_DEFROSTER\_SETTINGS\_IN\_CAR**: `5`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:420](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L420)
+
+***
+
+### SET\_MESSAGE\_ATTRIBUTE
+
+> **SET\_MESSAGE\_ATTRIBUTE**: `17`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:444](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L444)
+
+***
+
+### SET\_PROFILE\_IN\_CAR
+
+> **SET\_PROFILE\_IN\_CAR**: `7`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:424](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L424)
+
+***
+
+### SET\_RADIO\_STATION
+
+> **SET\_RADIO\_STATION**: `14`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:438](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L438)
+
+***
+
+### SET\_SEAT\_SETTINGS\_IN\_CAR
+
+> **SET\_SEAT\_SETTINGS\_IN\_CAR**: `6`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:422](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L422)
+
+***
+
+### START\_AUDIO\_CALL
+
+> **START\_AUDIO\_CALL**: `0`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:410](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L410)
+
+***
+
+### START\_PHOTO\_PLAYBACK
+
+> **START\_PHOTO\_PLAYBACK**: `21`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:452](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L452)
+
+***
+
+### START\_VIDEO\_CALL
+
+> **START\_VIDEO\_CALL**: `1`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:412](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L412)
+
+***
+
+### START\_WORKOUT
+
+> **START\_WORKOUT**: `9`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:428](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L428)

--- a/docs/react-native/reference/Enumeration.IOSNotificationSetting.mdx
+++ b/docs/react-native/reference/Enumeration.IOSNotificationSetting.mdx
@@ -1,0 +1,53 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationSetting
+
+# Enumeration: IOSNotificationSetting
+
+An enum representing a notification setting for this app on the device.
+
+Value is greater than 0 if setting enabled, compare against an exact value (e.g. NOT\_SUPPORTED) for more
+granular control.
+
+## Platform
+
+ios
+
+## Enumeration Members
+
+### DISABLED
+
+> **DISABLED**: `0`
+
+This setting is currently disabled by the user.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:328](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L328)
+
+***
+
+### ENABLED
+
+> **ENABLED**: `1`
+
+This setting is currently enabled.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:333](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L333)
+
+***
+
+### NOT\_SUPPORTED
+
+> **NOT\_SUPPORTED**: `-1`
+
+This setting is not supported on this device. Usually this means that the iOS version required
+for this setting has not been met.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:323](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L323)

--- a/docs/react-native/reference/Enumeration.IOSShowPreviewsSetting.mdx
+++ b/docs/react-native/reference/Enumeration.IOSShowPreviewsSetting.mdx
@@ -1,0 +1,65 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSShowPreviewsSetting
+
+# Enumeration: IOSShowPreviewsSetting
+
+An enum representing the show previews notification setting for this app on the device.
+
+Value is greater than 0 if previews are to be shown, compare against an exact value
+(e.g. WHEN\_AUTHENTICATED) for more granular control.
+
+## Platform
+
+ios
+
+## Enumeration Members
+
+### ALWAYS
+
+> **ALWAYS**: `1`
+
+Always show previews even if the device is currently locked.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:302](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L302)
+
+***
+
+### NEVER
+
+> **NEVER**: `0`
+
+Never show previews.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:297](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L297)
+
+***
+
+### NOT\_SUPPORTED
+
+> **NOT\_SUPPORTED**: `-1`
+
+This setting is not supported on this device. Usually this means that the iOS version required
+for this setting (iOS 11+) has not been met.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:292](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L292)
+
+***
+
+### WHEN\_AUTHENTICATED
+
+> **WHEN\_AUTHENTICATED**: `2`
+
+Only show previews when the device is unlocked.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:307](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L307)

--- a/docs/react-native/reference/Enumeration.RepeatFrequency.mdx
+++ b/docs/react-native/reference/Enumeration.RepeatFrequency.mdx
@@ -1,0 +1,51 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / RepeatFrequency
+
+# Enumeration: RepeatFrequency
+
+An interface representing the different frequencies which can be used with `TimestampTrigger.repeatFrequency`.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+
+## Enumeration Members
+
+### DAILY
+
+> **DAILY**: `1`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:80](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L80)
+
+***
+
+### HOURLY
+
+> **HOURLY**: `0`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:79](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L79)
+
+***
+
+### NONE
+
+> **NONE**: `-1`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:78](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L78)
+
+***
+
+### WEEKLY
+
+> **WEEKLY**: `2`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:81](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L81)

--- a/docs/react-native/reference/Enumeration.RepeatFrequency.mdx
+++ b/docs/react-native/reference/Enumeration.RepeatFrequency.mdx
@@ -8,7 +8,7 @@
 
 An interface representing the different frequencies which can be used with `TimestampTrigger.repeatFrequency`.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+View the [Triggers](/react-native/triggers) documentation to learn more.
 
 ## Enumeration Members
 

--- a/docs/react-native/reference/Enumeration.TimeUnit.mdx
+++ b/docs/react-native/reference/Enumeration.TimeUnit.mdx
@@ -8,7 +8,7 @@
 
 An interface representing the different units of time which can be used with `IntervalTrigger.timeUnit`.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+View the [Triggers](/react-native/triggers) documentation to learn more.
 
 ## Enumeration Members
 

--- a/docs/react-native/reference/Enumeration.TimeUnit.mdx
+++ b/docs/react-native/reference/Enumeration.TimeUnit.mdx
@@ -1,0 +1,51 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / TimeUnit
+
+# Enumeration: TimeUnit
+
+An interface representing the different units of time which can be used with `IntervalTrigger.timeUnit`.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+
+## Enumeration Members
+
+### DAYS
+
+> **DAYS**: `"DAYS"`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:123](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L123)
+
+***
+
+### HOURS
+
+> **HOURS**: `"HOURS"`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:122](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L122)
+
+***
+
+### MINUTES
+
+> **MINUTES**: `"MINUTES"`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:121](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L121)
+
+***
+
+### SECONDS
+
+> **SECONDS**: `"SECONDS"`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:120](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L120)

--- a/docs/react-native/reference/Enumeration.TriggerType.mdx
+++ b/docs/react-native/reference/Enumeration.TriggerType.mdx
@@ -1,0 +1,31 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / TriggerType
+
+# Enumeration: TriggerType
+
+Available Trigger Types.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more with example usage.
+
+## Enumeration Members
+
+### INTERVAL
+
+> **INTERVAL**: `1`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:133](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L133)
+
+***
+
+### TIMESTAMP
+
+> **TIMESTAMP**: `0`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:132](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L132)

--- a/docs/react-native/reference/Enumeration.TriggerType.mdx
+++ b/docs/react-native/reference/Enumeration.TriggerType.mdx
@@ -8,7 +8,7 @@
 
 Available Trigger Types.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more with example usage.
+View the [Triggers](/react-native/triggers) documentation to learn more with example usage.
 
 ## Enumeration Members
 

--- a/docs/react-native/reference/Interface.AndroidAction.mdx
+++ b/docs/react-native/reference/Interface.AndroidAction.mdx
@@ -1,0 +1,79 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidAction
+
+# Interface: AndroidAction
+
+The interface used to describe a notification quick action for Android.
+
+Notification actions allow users to interact with notifications, allowing you to handle events
+within your application. When an action completes (e.g. pressing an action, or filling out an input
+box) an event is sent.
+
+View the [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### icon?
+
+> `optional` **icon**: `string`
+
+An remote http or local icon path representing the action. Newer devices may not show the icon.
+
+Recommended icon size is 24x24 px.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:516](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L516)
+
+***
+
+### input?
+
+> `optional` **input**: `true` | [`AndroidInput`](react-native/reference/Interface.AndroidInput)
+
+If provided, the action accepts user input.
+
+If `true`, the user will be able to provide free text input when the action is pressed. This
+property can be further configured for advanced inputs.
+
+View the [Action Input](/react-native/docs/android/interaction#action-input) documentation to
+learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:527](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L527)
+
+***
+
+### pressAction
+
+> **pressAction**: [`NotificationPressAction`](react-native/reference/Interface.NotificationPressAction)
+
+The press action interface describing what happens when an action completes.
+
+Note; unlike the `pressAction` in the notification body, an action does not need to open the application
+and can perform background tasks. See the [AndroidPressAction](/react-native/reference/androidpressaction) reference
+or [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:504](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L504)
+
+***
+
+### title
+
+> **title**: `string`
+
+The title of the action, e.g. "Reply", "Mark as read" etc.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:509](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L509)

--- a/docs/react-native/reference/Interface.AndroidAction.mdx
+++ b/docs/react-native/reference/Interface.AndroidAction.mdx
@@ -12,7 +12,7 @@ Notification actions allow users to interact with notifications, allowing you to
 within your application. When an action completes (e.g. pressing an action, or filling out an input
 box) an event is sent.
 
-View the [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation to learn more.
+View the [Quick Actions](/react-native/android/interaction#quick-actions) documentation to learn more.
 
 ## Platform
 
@@ -43,7 +43,7 @@ If provided, the action accepts user input.
 If `true`, the user will be able to provide free text input when the action is pressed. This
 property can be further configured for advanced inputs.
 
-View the [Action Input](/react-native/docs/android/interaction#action-input) documentation to
+View the [Action Input](/react-native/android/interaction#action-input) documentation to
 learn more.
 
 #### Defined in
@@ -60,7 +60,7 @@ The press action interface describing what happens when an action completes.
 
 Note; unlike the `pressAction` in the notification body, an action does not need to open the application
 and can perform background tasks. See the [AndroidPressAction](/react-native/reference/androidpressaction) reference
-or [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation to learn more.
+or [Quick Actions](/react-native/android/interaction#quick-actions) documentation to learn more.
 
 #### Defined in
 

--- a/docs/react-native/reference/Interface.AndroidBigPictureStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidBigPictureStyle.mdx
@@ -10,7 +10,7 @@ The interface used when displaying a Big Picture Style notification.
 
 <Vimeo id="android-style-bigpicture" caption="Android Big Picture Style" />
 
-View the [Big Picture](/react-native/docs/android/styles#big-picture) documentation to learn more.
+View the [Big Picture](/react-native/android/styles#big-picture) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidBigPictureStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidBigPictureStyle.mdx
@@ -1,0 +1,84 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidBigPictureStyle
+
+# Interface: AndroidBigPictureStyle
+
+The interface used when displaying a Big Picture Style notification.
+
+<Vimeo id="android-style-bigpicture" caption="Android Big Picture Style" />
+
+View the [Big Picture](/react-native/docs/android/styles#big-picture) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### largeIcon?
+
+> `optional` **largeIcon**: `null` | `string` | `number` | `object`
+
+A local file path using the 'require()' method or a HTTP or file URL to the picture to display.
+
+If set, overrides the main notification `largeIcon` when the notification is expanded.
+
+To hide the `largeIcon` when the notification is expanded, set to null. Similar to `thumbnailHidden` for attachments on iOS.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:617](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L617)
+
+***
+
+### picture
+
+> **picture**: `string` | `number` | `object`
+
+A local file path using the 'require()' method or a HTTP or file URL to the picture to display.
+
+The image will be automatically resized depending on the device and it's size. If the image could
+not be found a blank space will appear.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:603](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L603)
+
+***
+
+### summary?
+
+> `optional` **summary**: `string`
+
+If set, overrides the main notification `summary` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:622](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L622)
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+If set, overrides the main notification `title` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:608](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L608)
+
+***
+
+### type
+
+> **type**: [`BIGPICTURE`](react-native/reference/Enumeration.AndroidStyle#bigpicture)
+
+Constant enum value used to identify the style type.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:595](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L595)

--- a/docs/react-native/reference/Interface.AndroidBigTextStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidBigTextStyle.mdx
@@ -10,7 +10,7 @@ The interface used when displaying a Big Text Style notification.
 
 <Vimeo id="android-style-bigtext" caption="Android Big Text Style" />
 
-View the [Big Text](/react-native/docs/android/styles#big-text) documentation to learn more.
+View the [Big Text](/react-native/android/styles#big-text) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidBigTextStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidBigTextStyle.mdx
@@ -1,0 +1,65 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidBigTextStyle
+
+# Interface: AndroidBigTextStyle
+
+The interface used when displaying a Big Text Style notification.
+
+<Vimeo id="android-style-bigtext" caption="Android Big Text Style" />
+
+View the [Big Text](/react-native/docs/android/styles#big-text) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### summary?
+
+> `optional` **summary**: `string`
+
+If set, overrides the main notification `summary` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:653](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L653)
+
+***
+
+### text
+
+> **text**: `string`
+
+The text to display when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:643](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L643)
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+If set, overrides the main notification `title` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:648](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L648)
+
+***
+
+### type
+
+> **type**: [`BIGTEXT`](react-native/reference/Enumeration.AndroidStyle#bigtext)
+
+Constant enum value used to identify the style type.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:638](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L638)

--- a/docs/react-native/reference/Interface.AndroidChannel.mdx
+++ b/docs/react-native/reference/Interface.AndroidChannel.mdx
@@ -1,0 +1,250 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidChannel
+
+# Interface: AndroidChannel
+
+An interface for describing an Android Channel.
+
+Channels override any individual notification preferences (e.g. lights/vibration) and the user
+has final control over the setting. Once created, only channel metadata can be updated (e.g. name).
+
+View the [Channels & Groups](/react-native/docs/android/channels) documentation to learn more.
+
+## Platform
+
+android
+
+## Extended by
+
+* [`NativeAndroidChannel`](react-native/reference/Interface.NativeAndroidChannel)
+
+## Properties
+
+### badge?
+
+> `optional` **badge**: `boolean`
+
+Sets whether badges are enabled for the channel.
+
+View the [Badges](/react-native/docs/android/appearance#badges) documentation to learn more.
+
+Defaults to `true`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:881](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L881)
+
+***
+
+### bypassDnd?
+
+> `optional` **bypassDnd**: `boolean`
+
+Sets whether or not notifications posted to this channel can interrupt the user in
+'Do Not Disturb' mode.
+
+Defaults to `false`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Platform
+
+android API Level >= 29
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:893](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L893)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+Sets the user visible description of this channel.
+
+The recommended maximum length is 300 characters; the value may be truncated if it is too long.
+
+This setting can be updated after creation.
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:904](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L904)
+
+***
+
+### groupId?
+
+> `optional` **groupId**: `string`
+
+Sets what group this channel belongs to. Group information is only used for presentation, not for behavior.
+
+Groups can be created via via [`createChannelGroup`](/react-native/reference/createchannelgroup).
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:931](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L931)
+
+***
+
+### id
+
+> **id**: `string`
+
+The unique channel ID.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:862](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L862)
+
+***
+
+### importance?
+
+> `optional` **importance**: [`AndroidImportance`](react-native/reference/Enumeration.AndroidImportance)
+
+Sets the level of interruption of this notification channel.
+
+Defaults to `AndroidImportance.DEFAULT`.
+
+This setting can only be set to a lower importance level once set.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:940](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L940)
+
+***
+
+### lightColor?
+
+> `optional` **lightColor**: `string`
+
+If lights are enabled (via `lights`), sets/overrides the light color for notifications
+posted to this channel.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:948](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L948)
+
+***
+
+### lights?
+
+> `optional` **lights**: `boolean`
+
+Sets whether notifications posted to this channel should display notification lights, on devices that support that feature.
+
+Defaults to `true`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:913](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L913)
+
+***
+
+### name
+
+> **name**: `string`
+
+The channel name. This is shown to the user so must be descriptive and relate to the notifications
+which will be delivered under this channel.
+
+This setting can be updated after creation.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:870](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L870)
+
+***
+
+### sound?
+
+> `optional` **sound**: `string`
+
+Overrides the sound the notification is displayed with.
+
+The default value is to play no sound. To play the default system sound use 'default'.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:976](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L976)
+
+***
+
+### soundURI?
+
+> `optional` **soundURI**: `string`
+
+The URI of the notification sound associated with the channel, if any.
+
+This is a read-only value, and is under user control after the channel is created
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:983](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L983)
+
+***
+
+### vibration?
+
+> `optional` **vibration**: `boolean`
+
+Sets whether notification posted to this channel should vibrate.
+
+Defaults to `true`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:922](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L922)
+
+***
+
+### vibrationPattern?
+
+> `optional` **vibrationPattern**: `number`\[]
+
+Sets/overrides the vibration pattern for notifications posted to this channel.
+
+The pattern in milliseconds. Must be an even amount of numbers.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:967](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L967)
+
+***
+
+### visibility?
+
+> `optional` **visibility**: [`AndroidVisibility`](react-native/reference/Enumeration.AndroidVisibility)
+
+Sets whether notifications posted to this channel appear on the lockscreen or not,
+and if so, whether they appear in a redacted form.
+
+Defaults to `AndroidVisibility.PRIVATE`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:958](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L958)

--- a/docs/react-native/reference/Interface.AndroidChannel.mdx
+++ b/docs/react-native/reference/Interface.AndroidChannel.mdx
@@ -11,7 +11,7 @@ An interface for describing an Android Channel.
 Channels override any individual notification preferences (e.g. lights/vibration) and the user
 has final control over the setting. Once created, only channel metadata can be updated (e.g. name).
 
-View the [Channels & Groups](/react-native/docs/android/channels) documentation to learn more.
+View the [Channels & Groups](/react-native/android/channels) documentation to learn more.
 
 ## Platform
 
@@ -29,7 +29,7 @@ android
 
 Sets whether badges are enabled for the channel.
 
-View the [Badges](/react-native/docs/android/appearance#badges) documentation to learn more.
+View the [Badges](/react-native/android/appearance#badges) documentation to learn more.
 
 Defaults to `true`.
 

--- a/docs/react-native/reference/Interface.AndroidChannelGroup.mdx
+++ b/docs/react-native/reference/Interface.AndroidChannelGroup.mdx
@@ -11,7 +11,7 @@ An interface for describing an Android Channel Group.
 Channel groups have no impact on the notification, they are used to help group channels in the applications
 settings UI.
 
-View the [Channels & Groups](/react-native/docs/android/channels) documentation to learn more.
+View the [Channels & Groups](/react-native/android/channels) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidChannelGroup.mdx
+++ b/docs/react-native/reference/Interface.AndroidChannelGroup.mdx
@@ -1,0 +1,67 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidChannelGroup
+
+# Interface: AndroidChannelGroup
+
+An interface for describing an Android Channel Group.
+
+Channel groups have no impact on the notification, they are used to help group channels in the applications
+settings UI.
+
+View the [Channels & Groups](/react-native/docs/android/channels) documentation to learn more.
+
+## Platform
+
+android API Level >= 26
+
+## Extended by
+
+* [`NativeAndroidChannelGroup`](react-native/reference/Interface.NativeAndroidChannelGroup)
+
+## Properties
+
+### description?
+
+> `optional` **description**: `string`
+
+An optional description of the group. This is visible to the user.
+
+On Android APIs less than 28 this will always be undefined.
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1039](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1039)
+
+***
+
+### id
+
+> **id**: `string`
+
+Unique id for this channel group.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1022](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1022)
+
+***
+
+### name
+
+> **name**: `string`
+
+The name of the group. This is visible to the user so should be a descriptive name which
+categorizes other channels (e.g. reminders).
+
+The recommended maximum length is 40 characters; the value may be truncated if it is too long.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1030](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1030)

--- a/docs/react-native/reference/Interface.AndroidInboxStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidInboxStyle.mdx
@@ -10,7 +10,7 @@ The interface used when displaying a Inbox Style notification.
 
 <Vimeo id="android-style-inbox" caption="Android Inbox Style" />
 
-View the [Inbox](/react-native/docs/android/styles#inbox) documentation to learn more.
+View the [Inbox](/react-native/android/styles#inbox) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidInboxStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidInboxStyle.mdx
@@ -1,0 +1,68 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidInboxStyle
+
+# Interface: AndroidInboxStyle
+
+The interface used when displaying a Inbox Style notification.
+
+<Vimeo id="android-style-inbox" caption="Android Inbox Style" />
+
+View the [Inbox](/react-native/docs/android/styles#inbox) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### lines
+
+> **lines**: `string`\[]
+
+An array of messages to display, in order provided.
+
+The device will automatically handle displaying the lines visible depending on space in the notification
+shade.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:677](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L677)
+
+***
+
+### summary?
+
+> `optional` **summary**: `string`
+
+If set, overrides the main notification `summary` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:687](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L687)
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+If set, overrides the main notification `title` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:682](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L682)
+
+***
+
+### type
+
+> **type**: [`INBOX`](react-native/reference/Enumeration.AndroidStyle#inbox)
+
+Constant enum value used to identify the style type.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:669](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L669)

--- a/docs/react-native/reference/Interface.AndroidInput.mdx
+++ b/docs/react-native/reference/Interface.AndroidInput.mdx
@@ -8,7 +8,7 @@
 
 The interface used to enable advanced user input on a notification.
 
-View the [Action Input](/react-native/docs/android/interaction#action-input) documentation to learn more.
+View the [Action Input](/react-native/android/interaction#action-input) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidInput.mdx
+++ b/docs/react-native/reference/Interface.AndroidInput.mdx
@@ -1,0 +1,93 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidInput
+
+# Interface: AndroidInput
+
+The interface used to enable advanced user input on a notification.
+
+View the [Action Input](/react-native/docs/android/interaction#action-input) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### allowFreeFormInput?
+
+> `optional` **allowFreeFormInput**: `boolean`
+
+Sets whether the user can freely enter text into the input.
+
+This value changes the behaviour of the notification:
+
+* If `true`, when an action is pressed this allows the user to type free form text into the input area.
+* If `false`, you must provide an array of `choices` the user is allowed to use as the input.
+
+Defaults to `true`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:548](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L548)
+
+***
+
+### allowGeneratedReplies?
+
+> `optional` **allowGeneratedReplies**: `boolean`
+
+Sets whether generated replies can be added to the action.
+
+Generated replies will only be shown if the input has `choices` and whether the device
+is able to generate replies.
+
+Defaults to `true`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:558](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L558)
+
+***
+
+### choices?
+
+> `optional` **choices**: `string`\[]
+
+An array of pre-defined input choices the user can select.
+
+If `allowFreeFormInput` is `false`, this property must contain at least one choice.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:565](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L565)
+
+***
+
+### editableChoices?
+
+> `optional` **editableChoices**: `boolean`
+
+If `true`, the user will be able to edit the selected choice before sending the action event, however
+`allowFreeFormInput` must also be `true`.
+
+By default, the platform will decide whether choices can be editable. To explicitly enable or disable
+this, provide `true` or `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:574](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L574)
+
+***
+
+### placeholder?
+
+> `optional` **placeholder**: `string`
+
+The placeholder text to display inside of the user input area.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:579](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L579)

--- a/docs/react-native/reference/Interface.AndroidMessagingStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidMessagingStyle.mdx
@@ -1,0 +1,77 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidMessagingStyle
+
+# Interface: AndroidMessagingStyle
+
+The interface used when displaying a Messaging Style notification.
+
+<Vimeo id="android-style-messaging" caption="Android Messaging Style" />
+
+View the [Messaging](/react-native/docs/android/styles#messaging) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### group?
+
+> `optional` **group**: `boolean`
+
+Sets whether this conversation notification represents a group (3 or more persons).
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:723](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L723)
+
+***
+
+### messages
+
+> **messages**: [`AndroidMessagingStyleMessage`](react-native/reference/Interface.AndroidMessagingStyleMessage)\[]
+
+An array of messages to display inside the notification.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:713](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L713)
+
+***
+
+### person
+
+> **person**: [`AndroidPerson`](react-native/reference/Interface.AndroidPerson)
+
+The person who is receiving a message on the current device.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:708](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L708)
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+If set, overrides the main notification `title` when the notification is expanded.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:718](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L718)
+
+***
+
+### type
+
+> **type**: [`MESSAGING`](react-native/reference/Enumeration.AndroidStyle#messaging)
+
+Constant enum value used to identify the style type.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:703](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L703)

--- a/docs/react-native/reference/Interface.AndroidMessagingStyle.mdx
+++ b/docs/react-native/reference/Interface.AndroidMessagingStyle.mdx
@@ -10,7 +10,7 @@ The interface used when displaying a Messaging Style notification.
 
 <Vimeo id="android-style-messaging" caption="Android Messaging Style" />
 
-View the [Messaging](/react-native/docs/android/styles#messaging) documentation to learn more.
+View the [Messaging](/react-native/android/styles#messaging) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidMessagingStyleMessage.mdx
+++ b/docs/react-native/reference/Interface.AndroidMessagingStyleMessage.mdx
@@ -11,7 +11,7 @@ The interface for messages when constructing a Messaging Style notification.
 <Vimeo id="android-style-messaging" caption="Android Messaging Style" />
 
 View the [`AndroidMessagingStyle`](/react-native/reference/androidmessagingstyle) reference
-and [Messaging](/react-native/docs/android/styles#messaging) documentation to learn more.
+and [Messaging](/react-native/android/styles#messaging) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidMessagingStyleMessage.mdx
+++ b/docs/react-native/reference/Interface.AndroidMessagingStyleMessage.mdx
@@ -1,0 +1,57 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidMessagingStyleMessage
+
+# Interface: AndroidMessagingStyleMessage
+
+The interface for messages when constructing a Messaging Style notification.
+
+<Vimeo id="android-style-messaging" caption="Android Messaging Style" />
+
+View the [`AndroidMessagingStyle`](/react-native/reference/androidmessagingstyle) reference
+and [Messaging](/react-native/docs/android/styles#messaging) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### person?
+
+> `optional` **person**: [`AndroidPerson`](react-native/reference/Interface.AndroidPerson)
+
+The sender of this message. See [`AndroidPerson`](/react-native/reference/androidperson) reference
+for more information on the properties available.
+
+This property should only be provided if the message is from an external person, and not the person receiving the message.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:753](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L753)
+
+***
+
+### text
+
+> **text**: `string`
+
+The content of the message.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:740](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L740)
+
+***
+
+### timestamp
+
+> **timestamp**: `number`
+
+The timestamp of when the message arrived in milliseconds.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:745](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L745)

--- a/docs/react-native/reference/Interface.AndroidNotificationSettings.mdx
+++ b/docs/react-native/reference/Interface.AndroidNotificationSettings.mdx
@@ -1,0 +1,23 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidNotificationSettings
+
+# Interface: AndroidNotificationSettings
+
+## Properties
+
+### alarm
+
+> **alarm**: [`AndroidNotificationSetting`](react-native/reference/Enumeration.AndroidNotificationSetting)
+
+Enum describing if you can create triggers
+
+For Android \< 12 / API \< 31, this will default to true
+
+View the [Trigger](/react-native/docs/android/triggers#android-12-limitations) documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:482](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L482)

--- a/docs/react-native/reference/Interface.AndroidNotificationSettings.mdx
+++ b/docs/react-native/reference/Interface.AndroidNotificationSettings.mdx
@@ -16,7 +16,7 @@ Enum describing if you can create triggers
 
 For Android \< 12 / API \< 31, this will default to true
 
-View the [Trigger](/react-native/docs/android/triggers#android-12-limitations) documentation for more information.
+View the [Trigger](/react-native/android/triggers#android-12-limitations) documentation for more information.
 
 #### Defined in
 

--- a/docs/react-native/reference/Interface.AndroidPerson.mdx
+++ b/docs/react-native/reference/Interface.AndroidPerson.mdx
@@ -1,0 +1,107 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidPerson
+
+# Interface: AndroidPerson
+
+The interface used to describe a person shown in notifications.
+
+Currently used with [`AndroidMessagingStyle`](/react-native/reference/androidmessagingstyle) notifications.
+
+## Platform
+
+android
+
+## Properties
+
+### bot?
+
+> `optional` **bot**: `boolean`
+
+If `true` this person represents a machine rather than a human. This is used primarily for testing and automated tooling.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:782](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L782)
+
+***
+
+### icon?
+
+> `optional` **icon**: `string`
+
+The icon to display next to the person in the notification. The icon can be URL or local
+Android resource.
+
+If not provided, an icon will be automatically creating using the `name` property.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:801](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L801)
+
+***
+
+### id?
+
+> `optional` **id**: `string`
+
+An optional unique ID of the person. Setting this property is preferred for unique identification,
+however not required. If no value is provided, the `name` will be used instead..
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:775](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L775)
+
+***
+
+### important?
+
+> `optional` **important**: `boolean`
+
+If `true` this person will be marked as important.
+
+Important users are those who frequently contact the receiving person. If the app is in
+"Do not disturb" mode, a notification containing an important person may override this mode
+if the person has been whitelisted on the device.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:793](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L793)
+
+***
+
+### name
+
+> **name**: `string`
+
+The name of the person.
+
+If no `id` is provided, the name will be used as the unique identifier.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:769](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L769)
+
+***
+
+### uri?
+
+> `optional` **uri**: `string`
+
+URI contact of the person.
+
+The URI can be any of the following:
+
+* The representation of a contact URI, e.g. `android.provider.ContactsContract.Contacts#CONTENT_LOOKUP_URI`
+* A `mailto:` string
+* A `tel:` string
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:812](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L812)

--- a/docs/react-native/reference/Interface.AndroidProgress.mdx
+++ b/docs/react-native/reference/Interface.AndroidProgress.mdx
@@ -10,7 +10,7 @@ Interface for defining the progress of an Android Notification.
 
 <Vimeo id="android-progress-summary" caption="Android Progress (w/ Big Picture Style)" />
 
-View the [Progress Indicators](/react-native/docs/android/progress-indicators) documentation to learn more.
+View the [Progress Indicators](/react-native/android/progress-indicators) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.AndroidProgress.mdx
+++ b/docs/react-native/reference/Interface.AndroidProgress.mdx
@@ -1,0 +1,60 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / AndroidProgress
+
+# Interface: AndroidProgress
+
+Interface for defining the progress of an Android Notification.
+
+<Vimeo id="android-progress-summary" caption="Android Progress (w/ Big Picture Style)" />
+
+View the [Progress Indicators](/react-native/docs/android/progress-indicators) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### current?
+
+> `optional` **current**: `number`
+
+The current progress value.
+
+E.g. setting to `4` with a `max` value of `10` would set a fixed progress bar on the notification at 40% complete.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:837](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L837)
+
+***
+
+### indeterminate?
+
+> `optional` **indeterminate**: `boolean`
+
+If `true`, overrides the `max` and `current` values and displays an unknown progress style. Useful when you have no
+knowledge of a tasks completion state.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:845](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L845)
+
+***
+
+### max?
+
+> `optional` **max**: `number`
+
+The maximum progress number. E.g `10`.
+
+Must be greater than the `current` value.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:830](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L830)

--- a/docs/react-native/reference/Interface.DisplayedNotification.mdx
+++ b/docs/react-native/reference/Interface.DisplayedNotification.mdx
@@ -1,0 +1,61 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / DisplayedNotification
+
+# Interface: DisplayedNotification
+
+An interface representing a notification that is currently displayed in the notification tray.
+
+## Properties
+
+### date?
+
+> `optional` **date**: `string`
+
+Date the notification was shown to the user
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:133](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L133)
+
+***
+
+### id?
+
+> `optional` **id**: `string`
+
+ID of the notification
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:128](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L128)
+
+***
+
+### notification
+
+> **notification**: [`Notification`](react-native/reference/Interface.Notification)
+
+The payload that was used to create the notification (if available)
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:138](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L138)
+
+***
+
+### trigger
+
+> **trigger**: [`Trigger`](react-native/reference/TypeAlias.Trigger)
+
+The trigger that was used to schedule the notification (if available)
+
+#### Platform
+
+iOS
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:145](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L145)

--- a/docs/react-native/reference/Interface.Event.mdx
+++ b/docs/react-native/reference/Interface.Event.mdx
@@ -1,0 +1,36 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / Event
+
+# Interface: Event
+
+An interface representing a Notifee event.
+
+View the [Events](/react-native/docs/events) documentation to learn more about foreground and
+background events.
+
+## Properties
+
+### detail
+
+> **detail**: [`EventDetail`](react-native/reference/Interface.EventDetail)
+
+An object containing event detail.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:178](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L178)
+
+***
+
+### type
+
+> **type**: [`EventType`](react-native/reference/Enumeration.EventType)
+
+The type of notification event.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:173](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L173)

--- a/docs/react-native/reference/Interface.Event.mdx
+++ b/docs/react-native/reference/Interface.Event.mdx
@@ -8,7 +8,7 @@
 
 An interface representing a Notifee event.
 
-View the [Events](/react-native/docs/events) documentation to learn more about foreground and
+View the [Events](/react-native/events) documentation to learn more about foreground and
 background events.
 
 ## Properties

--- a/docs/react-native/reference/Interface.EventDetail.mdx
+++ b/docs/react-native/reference/Interface.EventDetail.mdx
@@ -8,7 +8,7 @@
 
 An interface representing the different detail values which can be provided with a notification event.
 
-View the [Events](/react-native/docs/events) documentation to learn more.
+View the [Events](/react-native/events) documentation to learn more.
 
 ## Properties
 

--- a/docs/react-native/reference/Interface.EventDetail.mdx
+++ b/docs/react-native/reference/Interface.EventDetail.mdx
@@ -1,0 +1,131 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / EventDetail
+
+# Interface: EventDetail
+
+An interface representing the different detail values which can be provided with a notification event.
+
+View the [Events](/react-native/docs/events) documentation to learn more.
+
+## Properties
+
+### blocked?
+
+> `optional` **blocked**: `boolean`
+
+The notification blocked status of your entire application.
+
+The blocked detail is available when the event type is [`EventType.APP_BLOCKED`](/react-native/reference/eventtype#app_blocked).
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:461](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L461)
+
+***
+
+### channel?
+
+> `optional` **channel**: [`NativeAndroidChannel`](react-native/reference/Interface.NativeAndroidChannel)
+
+The channel that had its block state changed.
+
+Note that if the channel no longer exists during the time the event was sent the channel property will be undefined.
+
+The channel detail is available when the event type is [`EventType.CHANNEL_BLOCKED`](/react-native/reference/eventtype#channel_blocked).
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:441](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L441)
+
+***
+
+### channelGroup?
+
+> `optional` **channelGroup**: [`NativeAndroidChannelGroup`](react-native/reference/Interface.NativeAndroidChannelGroup)
+
+The channel group that had its block state changed.
+
+Note that if the channel no longer exists during the time the event was sent the channel group property will be undefined.
+
+The channel group detail is available when the event type is [`EventType.CHANNEL_GROUP_BLOCKED`](/react-native/reference/eventtype#channel_group_blocked).
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:452](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L452)
+
+***
+
+### input?
+
+> `optional` **input**: `string`
+
+The input from a notification action.
+
+The input detail is available when the [`EventType`](/react-native/reference/eventtype) is:
+
+* [`EventType.ACTION_PRESS`](/react-native/reference/eventtype#action_press)
+* The notification quick action has input enabled. View [`AndroidInput`](/react-native/reference/androidinput) for more details.
+
+#### Platform
+
+android API Level >= 20
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:430](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L430)
+
+***
+
+### notification?
+
+> `optional` **notification**: [`Notification`](react-native/reference/Interface.Notification)
+
+The notification this event relates to.
+
+The notification details is available when the [`EventType`](/react-native/reference/eventtype) is one of:
+
+* [`EventType.DISMISSED`](/react-native/reference/eventtype#dismissed)
+* [`EventType.PRESS`](/react-native/reference/eventtype#press)
+* [`EventType.ACTION_PRESS`](/react-native/reference/eventtype#action_press)
+* [`EventType.DELIVERED`](/react-native/reference/eventtype#delivered)
+* [`EventType.TRIGGER_NOTIFICATION_CREATED`](/react-native/reference/eventtype#trigger_notification_created)
+* [`EventType.FG_ALREADY_EXIST`](/react-native/reference/eventtype#fg_already_exist)
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:405](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L405)
+
+***
+
+### pressAction?
+
+> `optional` **pressAction**: [`NotificationPressAction`](react-native/reference/Interface.NotificationPressAction)
+
+The press action which triggered the event.
+
+If a press action caused the event, this property will be available allowing you to retrieve the
+action ID and perform logic.
+
+The press action details is available when the [`EventType`](/react-native/reference/eventtype) is one of:
+
+* [`EventType.PRESS`](/react-native/reference/eventtype#press)
+* [`EventType.ACTION_PRESS`](/react-native/reference/eventtype#action_press)
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:418](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L418)

--- a/docs/react-native/reference/Interface.IOSAttachmentThumbnailClippingRect.mdx
+++ b/docs/react-native/reference/Interface.IOSAttachmentThumbnailClippingRect.mdx
@@ -1,0 +1,58 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSAttachmentThumbnailClippingRect
+
+# Interface: IOSAttachmentThumbnailClippingRect
+
+The interface used to specify the portion of your image that you want to be displayed as the thumbnail
+
+Values are in the range 0.0 to 1.0.
+
+For example, specifying an origin (x,y) of (0.25, 0.25) and a size (width, height) of (0.5, 0.5)
+defines a clipping rectangle that shows only the center portion of the image.
+
+## Platform
+
+ios
+
+## Properties
+
+### height
+
+> **height**: `number`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:674](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L674)
+
+***
+
+### width
+
+> **width**: `number`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:673](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L673)
+
+***
+
+### x
+
+> **x**: `number`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:671](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L671)
+
+***
+
+### y
+
+> **y**: `number`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:672](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L672)

--- a/docs/react-native/reference/Interface.IOSCommunicationInfo.mdx
+++ b/docs/react-native/reference/Interface.IOSCommunicationInfo.mdx
@@ -1,0 +1,63 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSCommunicationInfo
+
+# Interface: IOSCommunicationInfo
+
+An interface to support communication notifications on iOS 15 and above
+
+## Platform
+
+ios
+
+## Properties
+
+### body?
+
+> `optional` **body**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:135](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L135)
+
+***
+
+### conversationId
+
+> **conversationId**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:134](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L134)
+
+***
+
+### groupAvatar?
+
+> `optional` **groupAvatar**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:137](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L137)
+
+***
+
+### groupName?
+
+> `optional` **groupName**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:136](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L136)
+
+***
+
+### sender
+
+> **sender**: [`IOSCommunicationInfoPerson`](react-native/reference/Interface.IOSCommunicationInfoPerson)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:138](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L138)

--- a/docs/react-native/reference/Interface.IOSCommunicationInfoPerson.mdx
+++ b/docs/react-native/reference/Interface.IOSCommunicationInfoPerson.mdx
@@ -1,0 +1,37 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSCommunicationInfoPerson
+
+# Interface: IOSCommunicationInfoPerson
+
+## Properties
+
+### avatar?
+
+> `optional` **avatar**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:144](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L144)
+
+***
+
+### displayName
+
+> **displayName**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:143](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L143)
+
+***
+
+### id
+
+> **id**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:142](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L142)

--- a/docs/react-native/reference/Interface.IOSForegroundPresentationOptions.mdx
+++ b/docs/react-native/reference/Interface.IOSForegroundPresentationOptions.mdx
@@ -10,7 +10,7 @@ An interface to customise how notifications are shown when the app is in the for
 
 By default, Notifee will show iOS notifications in heads-up mode if your app is currently in the foreground.
 
-View the [Foreground Notifications](/react-native/docs/ios/appearance#foreground-notifications) to learn
+View the [Foreground Notifications](/react-native/ios/appearance#foreground-notifications) to learn
 more.
 
 ## Platform

--- a/docs/react-native/reference/Interface.IOSForegroundPresentationOptions.mdx
+++ b/docs/react-native/reference/Interface.IOSForegroundPresentationOptions.mdx
@@ -1,0 +1,96 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSForegroundPresentationOptions
+
+# Interface: IOSForegroundPresentationOptions
+
+An interface to customise how notifications are shown when the app is in the foreground.
+
+By default, Notifee will show iOS notifications in heads-up mode if your app is currently in the foreground.
+
+View the [Foreground Notifications](/react-native/docs/ios/appearance#foreground-notifications) to learn
+more.
+
+## Platform
+
+ios
+
+## Properties
+
+### ~~alert?~~
+
+> `optional` **alert**: `boolean`
+
+App in foreground dialog box which indicates when a decision has to be made
+
+Defaults to true
+
+#### Deprecated
+
+Use `banner` and `list` instead
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:164](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L164)
+
+***
+
+### badge?
+
+> `optional` **badge**: `boolean`
+
+App in foreground badge update
+
+Defaults to true
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:178](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L178)
+
+***
+
+### banner?
+
+> `optional` **banner**: `boolean`
+
+Present the notification as a banner
+
+For iOS 13 and lower, will be equivalent to setting `alert` to true
+
+Defaults to true
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:187](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L187)
+
+***
+
+### list?
+
+> `optional` **list**: `boolean`
+
+Show the notification in Notification Center
+
+For iOS 13 and lower, will be equivalent to setting `alert` to true
+
+Defaults to true
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:196](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L196)
+
+***
+
+### sound?
+
+> `optional` **sound**: `boolean`
+
+App in foreground notification sound
+
+Defaults to true
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:171](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L171)

--- a/docs/react-native/reference/Interface.IOSInput.mdx
+++ b/docs/react-native/reference/Interface.IOSInput.mdx
@@ -1,0 +1,39 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSInput
+
+# Interface: IOSInput
+
+The interface used to enable advanced user input on a notification.
+
+View the [Action input](/react-native/docs/ios/interaction#action-input) documentation to learn more.
+
+## Platform
+
+ios
+
+## Properties
+
+### buttonText?
+
+> `optional` **buttonText**: `string`
+
+Overrides the default button text "Send", next to the input box.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:594](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L594)
+
+***
+
+### placeholderText?
+
+> `optional` **placeholderText**: `string`
+
+The placeholder text displayed in the text input field for this action.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:599](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L599)

--- a/docs/react-native/reference/Interface.IOSInput.mdx
+++ b/docs/react-native/reference/Interface.IOSInput.mdx
@@ -8,7 +8,7 @@
 
 The interface used to enable advanced user input on a notification.
 
-View the [Action input](/react-native/docs/ios/interaction#action-input) documentation to learn more.
+View the [Action input](/react-native/ios/interaction#action-input) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.IOSNotificationAttachment.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationAttachment.mdx
@@ -8,7 +8,7 @@
 
 An interface for describing an iOS Notification Attachment.
 
-View the [Attachments](/react-native/docs/ios/appearance#attachments) documentation to learn more.
+View the [Attachments](/react-native/ios/appearance#attachments) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.IOSNotificationAttachment.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationAttachment.mdx
@@ -1,0 +1,106 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationAttachment
+
+# Interface: IOSNotificationAttachment
+
+An interface for describing an iOS Notification Attachment.
+
+View the [Attachments](/react-native/docs/ios/appearance#attachments) documentation to learn more.
+
+## Platform
+
+ios
+
+## Properties
+
+### id?
+
+> `optional` **id**: `string`
+
+A optional unique identifier of the attachment.
+If no `id` is provided, a unique id is created for you.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:614](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L614)
+
+***
+
+### thumbnailClippingRect?
+
+> `optional` **thumbnailClippingRect**: [`IOSAttachmentThumbnailClippingRect`](react-native/reference/Interface.IOSAttachmentThumbnailClippingRect)
+
+An optional clipping rectangle for a thumbnail image.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:646](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L646)
+
+***
+
+### thumbnailHidden?
+
+> `optional` **thumbnailHidden**: `boolean`
+
+When set to `true` the thumbnail will be hidden.
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:641](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L641)
+
+***
+
+### thumbnailTime?
+
+> `optional` **thumbnailTime**: `number`
+
+The frame number of an animation to use as the thumbnail.
+
+For a video, it is the time (in seconds) into the video from which to
+grab the thumbnail image.
+
+For a GIF, it is the frame number of the animation to use
+as a thumbnail image.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:657](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L657)
+
+***
+
+### typeHint?
+
+> `optional` **typeHint**: `string`
+
+An optional hint about an attachment’s file type, as as Uniform Type Identifier (UTI).
+
+A list of UTI values can be found [here](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html) e.g. for JPEG you'd use `public.jpeg` as the `typeHint` value.
+
+If you do not include this key, the attachment’s filename extension is used to determine its type.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:635](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L635)
+
+***
+
+### url
+
+> **url**: `string`
+
+A URL to the media file to display.
+
+The value can be any of the following:
+
+* An absolute path to a file on the device
+* iOS resource
+
+For a list of supported file types, see [Supported File Types](https://developer.apple.com/documentation/usernotifications/unnotificationattachment#1682051) on the official Apple documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:626](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L626)

--- a/docs/react-native/reference/Interface.IOSNotificationCategory.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationCategory.mdx
@@ -1,0 +1,117 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationCategory
+
+# Interface: IOSNotificationCategory
+
+A interface representing a notification category created via [`setNotificationCategories`](/react-native/reference/setnotificationcategories).
+
+At minimum, a category must be created with a unique identifier, all other properties are optional.
+
+View the [Categories](/react-native/docs/ios/categories) documentation to learn more.
+
+## Platform
+
+ios
+
+## Properties
+
+### actions?
+
+> `optional` **actions**: [`IOSNotificationCategoryAction`](react-native/reference/Interface.IOSNotificationCategoryAction)\[]
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:532](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L532)
+
+***
+
+### allowAnnouncement?
+
+> `optional` **allowAnnouncement**: `boolean`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:499](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L499)
+
+***
+
+### allowInCarPlay?
+
+> `optional` **allowInCarPlay**: `boolean`
+
+Allow notifications in this category to be displayed in a CarPlay environment.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:488](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L488)
+
+***
+
+### hiddenPreviewsBodyPlaceholder?
+
+> `optional` **hiddenPreviewsBodyPlaceholder**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:520](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L520)
+
+***
+
+### hiddenPreviewsShowSubtitle?
+
+> `optional` **hiddenPreviewsShowSubtitle**: `boolean`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:513](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L513)
+
+***
+
+### hiddenPreviewsShowTitle?
+
+> `optional` **hiddenPreviewsShowTitle**: `boolean`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:506](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L506)
+
+***
+
+### id
+
+> **id**: `string`
+
+The unique ID for the category.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:474](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L474)
+
+***
+
+### intentIdentifiers?
+
+> `optional` **intentIdentifiers**: [`IOSIntentIdentifier`](react-native/reference/Enumeration.IOSIntentIdentifier)\[]
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:522](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L522)
+
+***
+
+### summaryFormat?
+
+> `optional` **summaryFormat**: `string`
+
+Specify a custom format for the summary text, which is visible when notifications are grouped together.
+
+View the [Summary Text](/react-native/docs/ios/categories#category-summary-text) documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:481](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L481)

--- a/docs/react-native/reference/Interface.IOSNotificationCategory.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationCategory.mdx
@@ -10,7 +10,7 @@ A interface representing a notification category created via [`setNotificationCa
 
 At minimum, a category must be created with a unique identifier, all other properties are optional.
 
-View the [Categories](/react-native/docs/ios/categories) documentation to learn more.
+View the [Categories](/react-native/ios/categories) documentation to learn more.
 
 ## Platform
 
@@ -110,7 +110,7 @@ The unique ID for the category.
 
 Specify a custom format for the summary text, which is visible when notifications are grouped together.
 
-View the [Summary Text](/react-native/docs/ios/categories#category-summary-text) documentation to learn more.
+View the [Summary Text](/react-native/ios/categories#category-summary-text) documentation to learn more.
 
 #### Defined in
 

--- a/docs/react-native/reference/Interface.IOSNotificationCategoryAction.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationCategoryAction.mdx
@@ -12,7 +12,7 @@ Quick actions allow users to interact with notifications, allowing you to handle
 within your application. When an action completes (e.g. pressing an action, or filling out an input
 box) an event is sent.
 
-View the [Quick Actions](/react-native/docs/ios/interaction#quick-actions) documentation to learn more.
+View the [Quick Actions](/react-native/ios/interaction#quick-actions) documentation to learn more.
 
 ## Platform
 
@@ -77,7 +77,7 @@ If `true`, the user will be able to provide free text input when the action is p
 The placeholder and button text can be customized by providing an object
 of type [`IOSInput`](/react-native/reference/iosinput).
 
-View the [Action Input](/react-native/docs/ios/interaction#action-input) documentation to
+View the [Action Input](/react-native/ios/interaction#action-input) documentation to
 learn more.
 
 #### Defined in

--- a/docs/react-native/reference/Interface.IOSNotificationCategoryAction.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationCategoryAction.mdx
@@ -1,0 +1,97 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationCategoryAction
+
+# Interface: IOSNotificationCategoryAction
+
+The interface used to describe a notification quick action for iOS.
+
+Quick actions allow users to interact with notifications, allowing you to handle events
+within your application. When an action completes (e.g. pressing an action, or filling out an input
+box) an event is sent.
+
+View the [Quick Actions](/react-native/docs/ios/interaction#quick-actions) documentation to learn more.
+
+## Platform
+
+ios
+
+## Properties
+
+### authenticationRequired?
+
+> `optional` **authenticationRequired**: `boolean`
+
+Whether this action should require unlocking before being performed.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:580](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L580)
+
+***
+
+### destructive?
+
+> `optional` **destructive**: `boolean`
+
+Makes the action red, indicating that the action is destructive.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:570](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L570)
+
+***
+
+### foreground?
+
+> `optional` **foreground**: `boolean`
+
+Whether this action should cause the application to launch in the foreground.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:575](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L575)
+
+***
+
+### id
+
+> **id**: `string`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:547](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L547)
+
+***
+
+### input?
+
+> `optional` **input**: `true` | [`IOSInput`](react-native/reference/Interface.IOSInput)
+
+If provided, the action accepts custom user input.
+
+If `true`, the user will be able to provide free text input when the action is pressed.
+
+The placeholder and button text can be customized by providing an object
+of type [`IOSInput`](/react-native/reference/iosinput).
+
+View the [Action Input](/react-native/docs/ios/interaction#action-input) documentation to
+learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:565](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L565)
+
+***
+
+### title
+
+> **title**: `string`
+
+The title of the action, e.g. "Reply", "Mark as read" etc.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:552](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L552)

--- a/docs/react-native/reference/Interface.IOSNotificationPermissions.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationPermissions.mdx
@@ -9,7 +9,7 @@
 An interface representing all the available permissions that can be requested by your app via
 the [`requestPermission`](/react-native/reference/requestpermission) API.
 
-View the [Permissions](/react-native/docs/ios/permissions) to learn
+View the [Permissions](/react-native/ios/permissions) to learn
 more.
 
 ## Platform
@@ -84,7 +84,7 @@ Defaults to true.
 
 Request permission to display critical notifications.
 
-View the [Critical Notifications](/react-native/docs/ios/behaviour#critical-notifications) documentation for more information
+View the [Critical Notifications](/react-native/ios/behaviour#critical-notifications) documentation for more information
 and usage examples.
 
 Defaults to false.

--- a/docs/react-native/reference/Interface.IOSNotificationPermissions.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationPermissions.mdx
@@ -1,0 +1,126 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationPermissions
+
+# Interface: IOSNotificationPermissions
+
+An interface representing all the available permissions that can be requested by your app via
+the [`requestPermission`](/react-native/reference/requestpermission) API.
+
+View the [Permissions](/react-native/docs/ios/permissions) to learn
+more.
+
+## Platform
+
+ios
+
+## Properties
+
+### alert?
+
+> `optional` **alert**: `boolean`
+
+Request permission to display alerts.
+
+Defaults to true.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:214](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L214)
+
+***
+
+### announcement?
+
+> `optional` **announcement**: `boolean`
+
+Request permission for Siri to automatically read out notification messages over AirPods.
+
+Defaults to false.
+
+#### Platform
+
+ios iOS >= 13
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:263](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L263)
+
+***
+
+### badge?
+
+> `optional` **badge**: `boolean`
+
+Request permission to update the application badge.
+
+Defaults to true.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:231](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L231)
+
+***
+
+### carPlay?
+
+> `optional` **carPlay**: `boolean`
+
+Request permission to display notifications in a CarPlay environment.
+
+Defaults to true.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:245](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L245)
+
+***
+
+### criticalAlert?
+
+> `optional` **criticalAlert**: `boolean`
+
+Request permission to display critical notifications.
+
+View the [Critical Notifications](/react-native/docs/ios/behaviour#critical-notifications) documentation for more information
+and usage examples.
+
+Defaults to false.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:224](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L224)
+
+***
+
+### provisional?
+
+> `optional` **provisional**: `boolean`
+
+Request permission to provisionally create non-interrupting notifications.
+
+Defaults to false.
+
+#### Platform
+
+ios iOS >= 12
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:254](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L254)
+
+***
+
+### sound?
+
+> `optional` **sound**: `boolean`
+
+Request permission to play sounds.
+
+Defaults to true.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:238](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L238)

--- a/docs/react-native/reference/Interface.IOSNotificationSettings.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationSettings.mdx
@@ -1,0 +1,152 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationSettings
+
+# Interface: IOSNotificationSettings
+
+An interface representing the current authorization status and notification-related settings for your app.
+
+This interface is returned from [`requestPermission`](/react-native/reference/requestpermission)
+and [`getNotificationSettings`](/react-native/reference/getnotificationsettings).
+
+View the [Observing Settings](/react-native/docs/ios/permissions#observing-settings) documentation to learn more.
+
+## Platform
+
+ios
+
+## Properties
+
+### alert
+
+> **alert**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications will alert the user.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:350](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L350)
+
+***
+
+### announcement
+
+> **announcement**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications can be announced to the user
+via 3rd party services such as Siri.
+
+For example, if the notification can be automatically read by Siri
+while the user is wearing AirPods.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:389](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L389)
+
+***
+
+### authorizationStatus
+
+> **authorizationStatus**: [`AuthorizationStatus`](react-native/reference/Enumeration.AuthorizationStatus)
+
+Overall notification authorization status for the application.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:401](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L401)
+
+***
+
+### badge
+
+> **badge**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications can update the application badge.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:355](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L355)
+
+***
+
+### carPlay
+
+> **carPlay**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications can be displayed in a CarPlay environment.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:375](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L375)
+
+***
+
+### criticalAlert
+
+> **criticalAlert**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if critical notifications are allowed.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:360](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L360)
+
+***
+
+### inAppNotificationSettings
+
+> **inAppNotificationSettings**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:396](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L396)
+
+***
+
+### lockScreen
+
+> **lockScreen**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications will be displayed on the lock screen.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:380](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L380)
+
+***
+
+### notificationCenter
+
+> **notificationCenter**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications will be displayed in the notification center.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:394](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L394)
+
+***
+
+### showPreviews
+
+> **showPreviews**: [`IOSShowPreviewsSetting`](react-native/reference/Enumeration.IOSShowPreviewsSetting)
+
+Enum describing if notification previews will be shown.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:365](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L365)
+
+***
+
+### sound
+
+> **sound**: [`IOSNotificationSetting`](react-native/reference/Enumeration.IOSNotificationSetting)
+
+Enum describing if notifications can trigger a sound.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:370](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L370)

--- a/docs/react-native/reference/Interface.IOSNotificationSettings.mdx
+++ b/docs/react-native/reference/Interface.IOSNotificationSettings.mdx
@@ -11,7 +11,7 @@ An interface representing the current authorization status and notification-rela
 This interface is returned from [`requestPermission`](/react-native/reference/requestpermission)
 and [`getNotificationSettings`](/react-native/reference/getnotificationsettings).
 
-View the [Observing Settings](/react-native/docs/ios/permissions#observing-settings) documentation to learn more.
+View the [Observing Settings](/react-native/ios/permissions#observing-settings) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.InitialNotification.mdx
+++ b/docs/react-native/reference/Interface.InitialNotification.mdx
@@ -1,0 +1,65 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / InitialNotification
+
+# Interface: InitialNotification
+
+An interface representing a notification & action that launched the current app / or Android activity.
+
+View the [App open events](/react-native/docs/events#app-open-events) documentation to learn more.
+
+This interface is returned from [`getInitialNotification`](/react-native/reference/getinitialnotification) when
+an initial notification is available.
+
+Deprecated for iOS in favour of `onForegroundEvent`
+
+## Platform
+
+android
+
+## Properties
+
+### input?
+
+> `optional` **input**: `string`
+
+The input from a notification action.
+
+The input detail is available when the [`EventType`](/react-native/reference/eventtype) is:
+
+* [`EventType.ACTION_PRESS`](/react-native/reference/eventtype#action_press)
+* The notification quick action has input enabled. View [`AndroidInput`](/react-native/reference/androidinput) for more details.
+
+#### Platform
+
+android API Level >= 20
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:118](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L118)
+
+***
+
+### notification
+
+> **notification**: [`Notification`](react-native/reference/Interface.Notification)
+
+The notification which the user interacted with, which caused the application to open.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:101](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L101)
+
+***
+
+### pressAction
+
+> **pressAction**: [`NotificationPressAction`](react-native/reference/Interface.NotificationPressAction)
+
+The press action which the user interacted with, on the notification, which caused the application to open.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:106](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L106)

--- a/docs/react-native/reference/Interface.InitialNotification.mdx
+++ b/docs/react-native/reference/Interface.InitialNotification.mdx
@@ -8,7 +8,7 @@
 
 An interface representing a notification & action that launched the current app / or Android activity.
 
-View the [App open events](/react-native/docs/events#app-open-events) documentation to learn more.
+View the [App open events](/react-native/events#app-open-events) documentation to learn more.
 
 This interface is returned from [`getInitialNotification`](/react-native/reference/getinitialnotification) when
 an initial notification is available.

--- a/docs/react-native/reference/Interface.IntervalTrigger.mdx
+++ b/docs/react-native/reference/Interface.IntervalTrigger.mdx
@@ -1,0 +1,55 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IntervalTrigger
+
+# Interface: IntervalTrigger
+
+Interface for building a trigger that repeats at a specified interval.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+
+## Properties
+
+### interval
+
+> **interval**: `number`
+
+How frequently the notification should be repeated.
+
+For example, if set to 30, the notification will be displayed every 30 minutes.
+
+Must be set to a minimum of 15 minutes.
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:102](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L102)
+
+***
+
+### timeUnit?
+
+> `optional` **timeUnit**: [`TimeUnit`](react-native/reference/Enumeration.TimeUnit)
+
+The unit of time that the `interval` is measured in.
+
+For example, if set to `TimeUnit.DAYS` and repeat interval is set to 3, the notification will repeat every 3 days.
+
+Defaults to `TimeUnit.SECONDS`
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:111](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L111)
+
+***
+
+### type
+
+> **type**: [`INTERVAL`](react-native/reference/Enumeration.TriggerType#interval)
+
+Constant enum value used to identify the trigger type.
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:93](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L93)

--- a/docs/react-native/reference/Interface.IntervalTrigger.mdx
+++ b/docs/react-native/reference/Interface.IntervalTrigger.mdx
@@ -8,7 +8,7 @@
 
 Interface for building a trigger that repeats at a specified interval.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+View the [Triggers](/react-native/triggers) documentation to learn more.
 
 ## Properties
 

--- a/docs/react-native/reference/Interface.NativeAndroidChannel.mdx
+++ b/docs/react-native/reference/Interface.NativeAndroidChannel.mdx
@@ -1,0 +1,313 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NativeAndroidChannel
+
+# Interface: NativeAndroidChannel
+
+An interface which describes a channel which has been fetched from the device.
+
+Contains additional information which is only available when fetching the channel from the device.
+
+## Platform
+
+android
+
+## Extends
+
+* [`AndroidChannel`](react-native/reference/Interface.AndroidChannel)
+
+## Properties
+
+### badge?
+
+> `optional` **badge**: `boolean`
+
+Sets whether badges are enabled for the channel.
+
+View the [Badges](/react-native/docs/android/appearance#badges) documentation to learn more.
+
+Defaults to `true`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`badge`](react-native/reference/Interface.AndroidChannel#badge)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:881](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L881)
+
+***
+
+### blocked
+
+> **blocked**: `boolean`
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1005](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1005)
+
+***
+
+### bypassDnd?
+
+> `optional` **bypassDnd**: `boolean`
+
+Sets whether or not notifications posted to this channel can interrupt the user in
+'Do Not Disturb' mode.
+
+Defaults to `false`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Platform
+
+android API Level >= 29
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`bypassDnd`](react-native/reference/Interface.AndroidChannel#bypassdnd)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:893](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L893)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+Sets the user visible description of this channel.
+
+The recommended maximum length is 300 characters; the value may be truncated if it is too long.
+
+This setting can be updated after creation.
+
+#### Platform
+
+android API Level >= 28
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`description`](react-native/reference/Interface.AndroidChannel#description)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:904](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L904)
+
+***
+
+### groupId?
+
+> `optional` **groupId**: `string`
+
+Sets what group this channel belongs to. Group information is only used for presentation, not for behavior.
+
+Groups can be created via via [`createChannelGroup`](/react-native/reference/createchannelgroup).
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`groupId`](react-native/reference/Interface.AndroidChannel#groupid)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:931](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L931)
+
+***
+
+### id
+
+> **id**: `string`
+
+The unique channel ID.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`id`](react-native/reference/Interface.AndroidChannel#id)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:862](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L862)
+
+***
+
+### importance?
+
+> `optional` **importance**: [`AndroidImportance`](react-native/reference/Enumeration.AndroidImportance)
+
+Sets the level of interruption of this notification channel.
+
+Defaults to `AndroidImportance.DEFAULT`.
+
+This setting can only be set to a lower importance level once set.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`importance`](react-native/reference/Interface.AndroidChannel#importance)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:940](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L940)
+
+***
+
+### lightColor?
+
+> `optional` **lightColor**: `string`
+
+If lights are enabled (via `lights`), sets/overrides the light color for notifications
+posted to this channel.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`lightColor`](react-native/reference/Interface.AndroidChannel#lightcolor)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:948](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L948)
+
+***
+
+### lights?
+
+> `optional` **lights**: `boolean`
+
+Sets whether notifications posted to this channel should display notification lights, on devices that support that feature.
+
+Defaults to `true`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`lights`](react-native/reference/Interface.AndroidChannel#lights)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:913](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L913)
+
+***
+
+### name
+
+> **name**: `string`
+
+The channel name. This is shown to the user so must be descriptive and relate to the notifications
+which will be delivered under this channel.
+
+This setting can be updated after creation.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`name`](react-native/reference/Interface.AndroidChannel#name)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:870](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L870)
+
+***
+
+### sound?
+
+> `optional` **sound**: `string`
+
+Overrides the sound the notification is displayed with.
+
+The default value is to play no sound. To play the default system sound use 'default'.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`sound`](react-native/reference/Interface.AndroidChannel#sound)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:976](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L976)
+
+***
+
+### soundURI?
+
+> `optional` **soundURI**: `string`
+
+The URI of the notification sound associated with the channel, if any.
+
+This is a read-only value, and is under user control after the channel is created
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`soundURI`](react-native/reference/Interface.AndroidChannel#sounduri)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:983](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L983)
+
+***
+
+### vibration?
+
+> `optional` **vibration**: `boolean`
+
+Sets whether notification posted to this channel should vibrate.
+
+Defaults to `true`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`vibration`](react-native/reference/Interface.AndroidChannel#vibration)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:922](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L922)
+
+***
+
+### vibrationPattern?
+
+> `optional` **vibrationPattern**: `number`\[]
+
+Sets/overrides the vibration pattern for notifications posted to this channel.
+
+The pattern in milliseconds. Must be an even amount of numbers.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`vibrationPattern`](react-native/reference/Interface.AndroidChannel#vibrationpattern)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:967](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L967)
+
+***
+
+### visibility?
+
+> `optional` **visibility**: [`AndroidVisibility`](react-native/reference/Enumeration.AndroidVisibility)
+
+Sets whether notifications posted to this channel appear on the lockscreen or not,
+and if so, whether they appear in a redacted form.
+
+Defaults to `AndroidVisibility.PRIVATE`.
+
+This setting cannot be overridden once the channel is created.
+
+#### Inherited from
+
+[`AndroidChannel`](react-native/reference/Interface.AndroidChannel).[`visibility`](react-native/reference/Interface.AndroidChannel#visibility)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:958](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L958)

--- a/docs/react-native/reference/Interface.NativeAndroidChannel.mdx
+++ b/docs/react-native/reference/Interface.NativeAndroidChannel.mdx
@@ -26,7 +26,7 @@ android
 
 Sets whether badges are enabled for the channel.
 
-View the [Badges](/react-native/docs/android/appearance#badges) documentation to learn more.
+View the [Badges](/react-native/android/appearance#badges) documentation to learn more.
 
 Defaults to `true`.
 

--- a/docs/react-native/reference/Interface.NativeAndroidChannelGroup.mdx
+++ b/docs/react-native/reference/Interface.NativeAndroidChannelGroup.mdx
@@ -29,7 +29,7 @@ blocked by the user.
 
 On API levels \< 28, returns `false`.
 
-View the [Listening to channel events](/react-native/docs/android/channels#listening-to-channel-events)
+View the [Listening to channel events](/react-native/android/channels#listening-to-channel-events)
 documentation to learn more about subscribing to when a channel is blocked by the user.
 
 #### Platform

--- a/docs/react-native/reference/Interface.NativeAndroidChannelGroup.mdx
+++ b/docs/react-native/reference/Interface.NativeAndroidChannelGroup.mdx
@@ -1,0 +1,110 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NativeAndroidChannelGroup
+
+# Interface: NativeAndroidChannelGroup
+
+An interface which describes a channel group which has been fetched from the device.
+
+Contains additional information which is only available when fetching the channel group from the device.
+
+## Platform
+
+android API Level >= 26
+
+## Extends
+
+* [`AndroidChannelGroup`](react-native/reference/Interface.AndroidChannelGroup)
+
+## Properties
+
+### blocked
+
+> **blocked**: `boolean`
+
+Returns whether or not notifications posted to a Channel belonging to this group are
+blocked by the user.
+
+On API levels \< 28, returns `false`.
+
+View the [Listening to channel events](/react-native/docs/android/channels#listening-to-channel-events)
+documentation to learn more about subscribing to when a channel is blocked by the user.
+
+#### Platform
+
+android API Level >= 28
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1061](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1061)
+
+***
+
+### channels
+
+> **channels**: [`NativeAndroidChannel`](react-native/reference/Interface.NativeAndroidChannel)\[]
+
+Returns a list of channels assigned to this channel group.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1066](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1066)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+An optional description of the group. This is visible to the user.
+
+On Android APIs less than 28 this will always be undefined.
+
+#### Platform
+
+android API Level >= 28
+
+#### Inherited from
+
+[`AndroidChannelGroup`](react-native/reference/Interface.AndroidChannelGroup).[`description`](react-native/reference/Interface.AndroidChannelGroup#description)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1039](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1039)
+
+***
+
+### id
+
+> **id**: `string`
+
+Unique id for this channel group.
+
+#### Inherited from
+
+[`AndroidChannelGroup`](react-native/reference/Interface.AndroidChannelGroup).[`id`](react-native/reference/Interface.AndroidChannelGroup#id)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1022](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1022)
+
+***
+
+### name
+
+> **name**: `string`
+
+The name of the group. This is visible to the user so should be a descriptive name which
+categorizes other channels (e.g. reminders).
+
+The recommended maximum length is 40 characters; the value may be truncated if it is too long.
+
+#### Inherited from
+
+[`AndroidChannelGroup`](react-native/reference/Interface.AndroidChannelGroup).[`name`](react-native/reference/Interface.AndroidChannelGroup#name)
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:1030](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L1030)

--- a/docs/react-native/reference/Interface.NativeError.mdx
+++ b/docs/react-native/reference/Interface.NativeError.mdx
@@ -1,0 +1,93 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NativeError
+
+# Interface: NativeError
+
+An Error that has occurred in native Android or iOS code converted into a JavaScript Error.
+
+## Extends
+
+* `Error`
+
+## Properties
+
+### code
+
+> `readonly` **code**: `string`
+
+Error code, e.g. `invalid-parameter`
+
+#### Defined in
+
+[packages/react-native/src/types/Library.ts:12](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Library.ts#L12)
+
+***
+
+### message
+
+> `readonly` **message**: `string`
+
+Error message
+
+#### Overrides
+
+`Error.message`
+
+#### Defined in
+
+[packages/react-native/src/types/Library.ts:17](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Library.ts#L17)
+
+***
+
+### name
+
+> **name**: `string`
+
+#### Inherited from
+
+`Error.name`
+
+#### Defined in
+
+node\_modules/typescript/lib/lib.es5.d.ts:1053
+
+***
+
+### nativeErrorCode
+
+> `readonly` **nativeErrorCode**: `string` | `number`
+
+The native returned error code, different per platform
+
+#### Defined in
+
+[packages/react-native/src/types/Library.ts:22](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Library.ts#L22)
+
+***
+
+### nativeErrorMessage
+
+> `readonly` **nativeErrorMessage**: `string`
+
+The native returned error message, different per platform
+
+#### Defined in
+
+[packages/react-native/src/types/Library.ts:27](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Library.ts#L27)
+
+***
+
+### stack?
+
+> `optional` **stack**: `string`
+
+#### Inherited from
+
+`Error.stack`
+
+#### Defined in
+
+node\_modules/typescript/lib/lib.es5.d.ts:1055

--- a/docs/react-native/reference/Interface.Notification.mdx
+++ b/docs/react-native/reference/Interface.Notification.mdx
@@ -1,0 +1,150 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / Notification
+
+# Interface: Notification
+
+Interface for building a local notification for both Android & iOS devices.
+
+To learn more about displaying a notification, view the [Displaying a Notification](/react-native/docs/displaying-a-notification)
+documentation.
+
+## Properties
+
+### android?
+
+> `optional` **android**: [`NotificationAndroid`](react-native/reference/Interface.NotificationAndroid)
+
+Android specific notification options. See the [`NotificationAndroid`](/react-native/reference/notificationandroid)
+interface for more information and default options which are applied to a notification.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:62](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L62)
+
+***
+
+### body?
+
+> `optional` **body**: `string`
+
+The main body content of a notification.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:46](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L46)
+
+***
+
+### data?
+
+> `optional` **data**: `object`
+
+Additional data to store on the notification.
+
+Data can be used to provide additional context to your notification which can be retrieved
+at a later point in time (e.g. via an event).
+
+#### Index Signature
+
+\[`key`: `string`]: `string` | `number` | `object`
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:54](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L54)
+
+***
+
+### id?
+
+> `optional` **id**: `string`
+
+A unique identifier for your notification.
+
+Notifications with the same ID will be created as the same instance, allowing you to update
+a notification which already exists on the device.
+
+Defaults to a random string if not provided.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:31](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L31)
+
+***
+
+### ios?
+
+> `optional` **ios**: [`NotificationIOS`](react-native/reference/Interface.NotificationIOS)
+
+iOS specific notification options. See the [`NotificationIOS`](/react-native/reference/notificationios)
+interface for more information and default options which are applied to a notification.
+
+#### Platform
+
+ios
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:70](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L70)
+
+***
+
+### remote?
+
+> `readonly` `optional` **remote**: `object`
+
+Will be populated if it's a remote notification
+
+#### contentAvailable?
+
+> `optional` **contentAvailable**: `number`
+
+#### messageId
+
+> **messageId**: `string`
+
+#### mutableContent?
+
+> `optional` **mutableContent**: `number`
+
+#### senderId
+
+> **senderId**: `string`
+
+#### Platform
+
+ios
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:77](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L77)
+
+***
+
+### subtitle?
+
+> `optional` **subtitle**: `string`
+
+The notification subtitle, which appears on a new line below/next the title.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:41](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L41)
+
+***
+
+### title?
+
+> `optional` **title**: `string`
+
+The notification title which appears above the body text.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:36](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L36)

--- a/docs/react-native/reference/Interface.Notification.mdx
+++ b/docs/react-native/reference/Interface.Notification.mdx
@@ -8,7 +8,7 @@
 
 Interface for building a local notification for both Android & iOS devices.
 
-To learn more about displaying a notification, view the [Displaying a Notification](/react-native/docs/displaying-a-notification)
+To learn more about displaying a notification, view the [Displaying a Notification](/react-native/displaying-a-notification)
 documentation.
 
 ## Properties

--- a/docs/react-native/reference/Interface.NotificationAndroid.mdx
+++ b/docs/react-native/reference/Interface.NotificationAndroid.mdx
@@ -1,0 +1,746 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NotificationAndroid
+
+# Interface: NotificationAndroid
+
+The interface for Android specific options which are applied to a notification.
+
+To learn more about Android notifications, view the [Android](/react-native/docs/android/introduction)
+documentation for full examples and usage.
+
+## Platform
+
+android
+
+## Properties
+
+### actions?
+
+> `optional` **actions**: [`AndroidAction`](react-native/reference/Interface.AndroidAction)\[]
+
+An array of [AndroidAction](/react-native/reference/androidaction) interfaces.
+
+Adds quick actions to a notification. Quick Actions enable users to interact with your application
+directly from the notification body, providing an overall greater user experience.
+
+View the [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:24](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L24)
+
+***
+
+### asForegroundService?
+
+> `optional` **asForegroundService**: `boolean`
+
+When set to `true` this notification will be shown as a foreground service.
+
+The application can only display one foreground service notification at once. If a
+foreground service notification is already running and a new notification with this flag set to
+`true` is provided, the service will stop the existing service and start a new one.
+
+Ensure a foreground service runner function has been provided to `registerForegroundService`.
+Without one, the notification will not be displayed.
+
+View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for more information.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:40](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L40)
+
+***
+
+### autoCancel?
+
+> `optional` **autoCancel**: `boolean`
+
+Setting this flag will make it so the notification is automatically canceled when the user
+presses it in the panel.
+
+By default when the user taps a notification it is automatically removed from the notification
+panel. Setting this to `false` will keep the notification in the panel.
+
+If `false`, the notification will persist in the notification panel after being pressed. It will
+remain there until the user removes it (e.g. swipes away) or is cancelled via
+[`cancelNotification`](/react-native/reference/cancelNotification).
+
+Defaults to `true`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:62](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L62)
+
+***
+
+### badgeCount?
+
+> `optional` **badgeCount**: `number`
+
+Overrides the current number of active notifications shown on the device.
+
+If no number is provided, the system displays the current number of active notifications.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:69](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L69)
+
+***
+
+### badgeIconType?
+
+> `optional` **badgeIconType**: [`AndroidBadgeIconType`](react-native/reference/Enumeration.AndroidBadgeIconType)
+
+Sets the type of badge used when the notification is being displayed in badge mode.
+
+View the [Badges](/react-native/docs/android/appearance#badges) documentation for more information
+and usage examples.
+
+Defaults to `AndroidBadgeIconType.LARGE`.
+
+#### Platform
+
+android API Level >= 26
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:81](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L81)
+
+***
+
+### category?
+
+> `optional` **category**: [`AndroidCategory`](react-native/reference/Enumeration.AndroidCategory)
+
+Assigns the notification to a category. Use the one which best describes the notification.
+
+The category may be used by the device for ranking and filtering. It has no visual or behavioural
+impact.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:89](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L89)
+
+***
+
+### channelId?
+
+> `optional` **channelId**: `string`
+
+Specifies the `AndroidChannel` which the notification will be delivered on.
+
+On Android 8.0 (API 26) the channel ID is required. Providing a invalid channel ID will throw
+an error. View the [Channels & Groups](/react-native/docs/android/channels) documentation for
+more information and usage examples.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:98](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L98)
+
+***
+
+### chronometerDirection?
+
+> `optional` **chronometerDirection**: `"up"` | `"down"`
+
+If `showChronometer` is `true`, the direction of the chronometer can be changed to count down instead of up.
+
+Has no effect if `showChronometer` is `false`.
+
+Defaults to `up`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:131](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L131)
+
+***
+
+### circularLargeIcon?
+
+> `optional` **circularLargeIcon**: `boolean`
+
+Whether the large icon should be circular.
+
+If `true`, the large icon will be rounded in the shape of a circle.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:205](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L205)
+
+***
+
+### color?
+
+> `optional` **color**: `string`
+
+Set an custom accent color for the notification. If not provided, the default notification
+system color will be used.
+
+The color can be a predefined system `AndroidColor` or [hexadecimal](https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4).
+
+View the [Color](/react-native/docs/android/appearance#color) documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:108](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L108)
+
+***
+
+### colorized?
+
+> `optional` **colorized**: `boolean`
+
+When `asForegroundService` is `true`, the notification will use the provided `color` property
+to set a background color on the notification. This property has no effect when `asForegroundService`
+is `false`.
+
+This should only be used for high priority ongoing tasks like navigation, an ongoing call,
+or other similarly high-priority events for the user.
+
+View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for more information.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:122](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L122)
+
+***
+
+### defaults?
+
+> `optional` **defaults**: [`AndroidDefaults`](react-native/reference/Enumeration.AndroidDefaults)\[]
+
+For devices without notification channel support, this property sets the default behaviour
+for a notification.
+
+On API Level >= 26, this has no effect.
+
+See [AndroidDefaults](/react-native/reference/androiddefaults) for more information.
+
+#### Platform
+
+android API Level \< 26
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:143](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L143)
+
+***
+
+### flags?
+
+> `optional` **flags**: [`AndroidFlags`](react-native/reference/Enumeration.AndroidFlags)\[]
+
+Set any additional flags
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:251](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L251)
+
+***
+
+### foregroundServiceTypes?
+
+> `optional` **foregroundServiceTypes**: [`AndroidForegroundServiceType`](react-native/reference/Enumeration.AndroidForegroundServiceType)\[]
+
+Set the foreground service types identifying the work done by the service
+
+View the [Foreground service types](https://developer.android.com/develop/background-work/services/fg-service-types) documentation to learn
+more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:289](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L289)
+
+***
+
+### fullScreenAction?
+
+> `optional` **fullScreenAction**: [`NotificationFullScreenAction`](react-native/reference/Interface.NotificationFullScreenAction)
+
+The `fullScreenAction` property allows you to show a custom UI
+in full screen when the notification is displayed.
+
+View the [FullScreenAction](/react-native/docs/android/behaviour#full-screen) documentation to learn
+more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:281](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L281)
+
+***
+
+### groupAlertBehavior?
+
+> `optional` **groupAlertBehavior**: [`AndroidGroupAlertBehavior`](react-native/reference/Enumeration.AndroidGroupAlertBehavior)
+
+Sets the group alert behavior for this notification. Use this method to mute this notification
+if alerts for this notification's group should be handled by a different notification. This is
+only applicable for notifications that belong to a `groupId`. This must be called on all notifications
+you want to mute. For example, if you want only the summary of your group to make noise, all
+children in the group should have the group alert behavior `AndroidGroupAlertBehavior.SUMMARY`.
+
+View the [Android Grouping & Sorting guide](/react-native/docs/android/grouping-and-sorting#group-behaviour)
+documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:166](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L166)
+
+***
+
+### groupId?
+
+> `optional` **groupId**: `string`
+
+Set this notification to be part of a group of notifications sharing the same key. Grouped notifications may
+display in a cluster or stack on devices which support such rendering.
+
+On some devices, the system may automatically group notifications.
+
+View the [Android Grouping & Sorting guide](/react-native/docs/android/grouping-and-sorting) documentation to
+learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:154](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L154)
+
+***
+
+### groupSummary?
+
+> `optional` **groupSummary**: `boolean`
+
+Whether this notification should be a group summary.
+
+If `true`, Set this notification to be the group summary for a group of notifications. Grouped notifications may display in
+a cluster or stack on devices which support such rendering. Requires a `groupId` key to be set.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:176](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L176)
+
+***
+
+### importance?
+
+> `optional` **importance**: [`AndroidImportance`](react-native/reference/Enumeration.AndroidImportance)
+
+Set a notification importance for devices without channel support.
+
+Devices using Android API Level \< 26 have no channel support, meaning incoming notifications
+won't be assigned an importance level from the channel. If your application supports devices
+without channel support, set this property to directly assign an importance level to the incoming
+notification.
+
+Defaults to `AndroidImportance.DEFAULT`.
+
+View the [Appearance](/react-native/docs/android/appearance#importance) documentation to learn
+more.
+
+#### Platform
+
+android API Level \< 26
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:306](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L306)
+
+***
+
+### inputHistory?
+
+> `optional` **inputHistory**: `string`\[]
+
+The local user input history for this notification.
+
+Input history is shown on supported devices below the main notification body. History of the
+users input with the notification should be shown when receiving action input by updating
+the existing notification. It is recommended to clear the history when it is no longer
+relevant (e.g. someone has responded to the users input).
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:186](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L186)
+
+***
+
+### largeIcon?
+
+> `optional` **largeIcon**: `string` | `number` | `object`
+
+A local file path using the 'require()' method or a remote http to the picture to display.
+
+Sets a large icon on the notification.
+
+View the [Android Appearance](/react-native/docs/android/appearance#large-icons) documentation to learn
+more about this property.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:196](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L196)
+
+***
+
+### lights?
+
+> `optional` **lights**: \[`string`, `number`, `number`]
+
+Sets the color and frequency of the light pattern. This only has effect on supported devices.
+
+The option takes an array containing a hexadecimal color value or predefined `AndroidColor`,
+along with the number of milliseconds to show the light, and the number of milliseconds to
+turn off the light. The light frequency pattern is repeated.
+
+View the [Lights](/react-native/docs/android/behaviour#lights) documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:216](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L216)
+
+***
+
+### lightUpScreen?
+
+> `optional` **lightUpScreen**: `boolean`
+
+When set to `true` the screen will light up when the notification is displayed.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:47](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L47)
+
+***
+
+### localOnly?
+
+> `optional` **localOnly**: `boolean`
+
+Sets whether the notification will only appear on the local device.
+
+Users who have connected devices which support notifications (such as a smart watch) will
+receive an alert for the notification on that device. If set to `true`, the notification will
+only alert on the main device.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:227](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L227)
+
+***
+
+### loopSound?
+
+> `optional` **loopSound**: `boolean`
+
+Set whether the sound should loop, by default, the sound will only play once.
+
+This property is useful if you have an ongoing notification.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:246](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L246)
+
+***
+
+### ongoing?
+
+> `optional` **ongoing**: `boolean`
+
+Set whether this is an on-going notification.
+
+Setting this value to `true` changes the default behaviour of a notification:
+
+* Ongoing notifications are sorted above the regular notifications in the notification panel.
+* Ongoing notifications do not have an 'X' close button, and are not affected by the "Clear all" button.
+
+View the [Ongoing](/react-native/docs/android/behaviour#ongoing) documentation for more information.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:239](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L239)
+
+***
+
+### onlyAlertOnce?
+
+> `optional` **onlyAlertOnce**: `boolean`
+
+Notifications with the same `id` will only show a single instance at any one time on your device,
+however will still alert the user (for example, by making a sound).
+
+If this flag is set to `true`, notifications with the same `id` will only alert the user once whilst
+the notification is visible.
+
+This property is commonly used when frequently updating a notification (such as updating the progress bar).
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:262](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L262)
+
+***
+
+### pressAction?
+
+> `optional` **pressAction**: [`NotificationPressAction`](react-native/reference/Interface.NotificationPressAction)
+
+By default notifications have no behaviour when a user presses them. The
+`pressAction` property allows you to set what happens when a user presses
+the notification.
+
+View the [Interaction](/react-native/docs/android/interaction) documentation to learn
+more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:272](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L272)
+
+***
+
+### progress?
+
+> `optional` **progress**: [`AndroidProgress`](react-native/reference/Interface.AndroidProgress)
+
+A notification can show current progress of a task. The progress state can either be fixed or
+indeterminate (unknown).
+
+View the [Progress Indicators](/react-native/docs/android/progress-indicators) documentation
+to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:315](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L315)
+
+***
+
+### showChronometer?
+
+> `optional` **showChronometer**: `boolean`
+
+Shows a counting timer on the notification, useful for on-going notifications such as a phone call.
+
+If no `timestamp` is provided, a counter will display on the notification starting from 00:00. If a `timestamp` is
+provided, the number of hours/minutes/seconds since that have elapsed since that value will be shown instead.
+
+Defaults to `false`.
+
+View the [Timers](/react-native/docs/android/timers#timers) documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:390](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L390)
+
+***
+
+### showTimestamp?
+
+> `optional` **showTimestamp**: `boolean`
+
+Sets whether the `timestamp` provided is shown in the notification.
+
+Setting this field is useful for notifications which are more informative with a timestamp,
+such as an E-Mail.
+
+If no `timestamp` is set, this field has no effect.
+
+View the [Timestamps](/react-native/docs/android/timers#timestamps) documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:327](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L327)
+
+***
+
+### smallIcon?
+
+> `optional` **smallIcon**: `string`
+
+The small icon to show in the heads-up notification.
+
+View the [Icons](/react-native/docs/android/appearance#small-icons) documentation to learn
+more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:335](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L335)
+
+***
+
+### smallIconLevel?
+
+> `optional` **smallIconLevel**: `number`
+
+An additional level parameter for when the icon is an instance of a Android `LevelListDrawable`.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:340](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L340)
+
+***
+
+### sortKey?
+
+> `optional` **sortKey**: `string`
+
+Set a sort key that orders this notification among other notifications from the same package.
+This can be useful if an external sort was already applied and an app would like to preserve
+this. Notifications will be sorted lexicographically using this value, although providing
+different priorities in addition to providing sort key may cause this value to be ignored.
+
+If a `groupId` has been set, the sort key can also be used to order members of a notification group.
+
+View the [Android Grouping & Sorting](/react-native/docs/android/grouping-and-sorting#sorting)
+documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:353](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L353)
+
+***
+
+### sound?
+
+> `optional` **sound**: `string`
+
+Overrides the sound the notification is displayed with.
+
+The default value is to play no sound. To play the default system sound use 'default'.
+
+This setting has no behaviour on Android after API level version 26, instead you can set the
+sound on the notification channels.
+
+View the [Sound](/react-native/docs/android/behaviour#sound) documentation for more information.
+
+#### Platform
+
+android API Level \< 26
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:442](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L442)
+
+***
+
+### style?
+
+> `optional` **style**: [`AndroidBigPictureStyle`](react-native/reference/Interface.AndroidBigPictureStyle) | [`AndroidBigTextStyle`](react-native/reference/Interface.AndroidBigTextStyle) | [`AndroidInboxStyle`](react-native/reference/Interface.AndroidInboxStyle) | [`AndroidMessagingStyle`](react-native/reference/Interface.AndroidMessagingStyle)
+
+Styled notifications provide users with more informative content and additional functionality.
+
+Android supports different styles, however only one can be used with a notification.
+
+View the [Styles](/react-native/docs/android/styles) documentation to learn more
+view usage examples.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:363](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L363)
+
+***
+
+### tag?
+
+> `optional` **tag**: `string`
+
+Sets a tag on the notification.
+
+Tags can be used to query groups notifications by the tag value. Setting a tag has no
+impact on the notification itself.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:416](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L416)
+
+***
+
+### ticker?
+
+> `optional` **ticker**: `string`
+
+Text that summarizes this notification for accessibility services. As of the Android L release, this
+text is no longer shown on screen, but it is still useful to accessibility services
+(where it serves as an audible announcement of the notification's appearance).
+
+Ticker text does not show in the notification.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:372](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L372)
+
+***
+
+### timeoutAfter?
+
+> `optional` **timeoutAfter**: `number`
+
+Sets the time in milliseconds at which the notification should be
+automatically cancelled once displayed, if it is not already cancelled.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:378](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L378)
+
+***
+
+### timestamp?
+
+> `optional` **timestamp**: `number`
+
+The timestamp in milliseconds for this notification. Notifications in the panel are sorted by this time.
+
+The timestamp can be used with other properties to change the behaviour of a notification:
+
+* Use with `showTimestamp` to show the timestamp to the users.
+* Use with `showChronometer` to create a on-going timer.
+
+View the [Timers](/react-native/docs/android/timers) documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:428](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L428)
+
+***
+
+### vibrationPattern?
+
+> `optional` **vibrationPattern**: `number`\[]
+
+Sets the vibration pattern the notification uses when displayed. Must be an even amount of numbers.
+
+View the [Vibration](/react-native/docs/android/behaviour#vibration) documentation to learn more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:397](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L397)
+
+***
+
+### visibility?
+
+> `optional` **visibility**: [`AndroidVisibility`](react-native/reference/Enumeration.AndroidVisibility)
+
+Sets the visibility for this notification. This may be used for apps which show user
+sensitive information (e.g. a banking app).
+
+Defaults to `AndroidVisibility.PRIVATE`.
+
+View the [Visibility](/react-native/docs/android/appearance#visibility) documentation to learn
+more.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationAndroid.ts:408](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationAndroid.ts#L408)

--- a/docs/react-native/reference/Interface.NotificationAndroid.mdx
+++ b/docs/react-native/reference/Interface.NotificationAndroid.mdx
@@ -8,7 +8,7 @@
 
 The interface for Android specific options which are applied to a notification.
 
-To learn more about Android notifications, view the [Android](/react-native/docs/android/introduction)
+To learn more about Android notifications, view the [Android](/react-native/android/introduction)
 documentation for full examples and usage.
 
 ## Platform
@@ -26,7 +26,7 @@ An array of [AndroidAction](/react-native/reference/androidaction) interfaces.
 Adds quick actions to a notification. Quick Actions enable users to interact with your application
 directly from the notification body, providing an overall greater user experience.
 
-View the [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation for more information.
+View the [Quick Actions](/react-native/android/interaction#quick-actions) documentation for more information.
 
 #### Defined in
 
@@ -47,7 +47,7 @@ foreground service notification is already running and a new notification with t
 Ensure a foreground service runner function has been provided to `registerForegroundService`.
 Without one, the notification will not be displayed.
 
-View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for more information.
+View the [Foreground Service](/react-native/android/foreground-service) documentation for more information.
 
 Defaults to `false`.
 
@@ -99,7 +99,7 @@ If no number is provided, the system displays the current number of active notif
 
 Sets the type of badge used when the notification is being displayed in badge mode.
 
-View the [Badges](/react-native/docs/android/appearance#badges) documentation for more information
+View the [Badges](/react-native/android/appearance#badges) documentation for more information
 and usage examples.
 
 Defaults to `AndroidBadgeIconType.LARGE`.
@@ -136,7 +136,7 @@ impact.
 Specifies the `AndroidChannel` which the notification will be delivered on.
 
 On Android 8.0 (API 26) the channel ID is required. Providing a invalid channel ID will throw
-an error. View the [Channels & Groups](/react-native/docs/android/channels) documentation for
+an error. View the [Channels & Groups](/react-native/android/channels) documentation for
 more information and usage examples.
 
 #### Defined in
@@ -186,7 +186,7 @@ system color will be used.
 
 The color can be a predefined system `AndroidColor` or [hexadecimal](https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4).
 
-View the [Color](/react-native/docs/android/appearance#color) documentation for more information.
+View the [Color](/react-native/android/appearance#color) documentation for more information.
 
 #### Defined in
 
@@ -205,7 +205,7 @@ is `false`.
 This should only be used for high priority ongoing tasks like navigation, an ongoing call,
 or other similarly high-priority events for the user.
 
-View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for more information.
+View the [Foreground Service](/react-native/android/foreground-service) documentation for more information.
 
 Defaults to `false`.
 
@@ -270,7 +270,7 @@ more.
 The `fullScreenAction` property allows you to show a custom UI
 in full screen when the notification is displayed.
 
-View the [FullScreenAction](/react-native/docs/android/behaviour#full-screen) documentation to learn
+View the [FullScreenAction](/react-native/android/behaviour#full-screen) documentation to learn
 more.
 
 #### Defined in
@@ -289,7 +289,7 @@ only applicable for notifications that belong to a `groupId`. This must be calle
 you want to mute. For example, if you want only the summary of your group to make noise, all
 children in the group should have the group alert behavior `AndroidGroupAlertBehavior.SUMMARY`.
 
-View the [Android Grouping & Sorting guide](/react-native/docs/android/grouping-and-sorting#group-behaviour)
+View the [Android Grouping & Sorting guide](/react-native/android/grouping-and-sorting#group-behaviour)
 documentation to learn more.
 
 #### Defined in
@@ -307,7 +307,7 @@ display in a cluster or stack on devices which support such rendering.
 
 On some devices, the system may automatically group notifications.
 
-View the [Android Grouping & Sorting guide](/react-native/docs/android/grouping-and-sorting) documentation to
+View the [Android Grouping & Sorting guide](/react-native/android/grouping-and-sorting) documentation to
 learn more.
 
 #### Defined in
@@ -346,7 +346,7 @@ notification.
 
 Defaults to `AndroidImportance.DEFAULT`.
 
-View the [Appearance](/react-native/docs/android/appearance#importance) documentation to learn
+View the [Appearance](/react-native/android/appearance#importance) documentation to learn
 more.
 
 #### Platform
@@ -384,7 +384,7 @@ A local file path using the 'require()' method or a remote http to the picture t
 
 Sets a large icon on the notification.
 
-View the [Android Appearance](/react-native/docs/android/appearance#large-icons) documentation to learn
+View the [Android Appearance](/react-native/android/appearance#large-icons) documentation to learn
 more about this property.
 
 #### Defined in
@@ -403,7 +403,7 @@ The option takes an array containing a hexadecimal color value or predefined `An
 along with the number of milliseconds to show the light, and the number of milliseconds to
 turn off the light. The light frequency pattern is repeated.
 
-View the [Lights](/react-native/docs/android/behaviour#lights) documentation for more information.
+View the [Lights](/react-native/android/behaviour#lights) documentation for more information.
 
 #### Defined in
 
@@ -468,7 +468,7 @@ Setting this value to `true` changes the default behaviour of a notification:
 * Ongoing notifications are sorted above the regular notifications in the notification panel.
 * Ongoing notifications do not have an 'X' close button, and are not affected by the "Clear all" button.
 
-View the [Ongoing](/react-native/docs/android/behaviour#ongoing) documentation for more information.
+View the [Ongoing](/react-native/android/behaviour#ongoing) documentation for more information.
 
 #### Defined in
 
@@ -502,7 +502,7 @@ By default notifications have no behaviour when a user presses them. The
 `pressAction` property allows you to set what happens when a user presses
 the notification.
 
-View the [Interaction](/react-native/docs/android/interaction) documentation to learn
+View the [Interaction](/react-native/android/interaction) documentation to learn
 more.
 
 #### Defined in
@@ -518,7 +518,7 @@ more.
 A notification can show current progress of a task. The progress state can either be fixed or
 indeterminate (unknown).
 
-View the [Progress Indicators](/react-native/docs/android/progress-indicators) documentation
+View the [Progress Indicators](/react-native/android/progress-indicators) documentation
 to learn more.
 
 #### Defined in
@@ -538,7 +538,7 @@ provided, the number of hours/minutes/seconds since that have elapsed since that
 
 Defaults to `false`.
 
-View the [Timers](/react-native/docs/android/timers#timers) documentation to learn more.
+View the [Timers](/react-native/android/timers#timers) documentation to learn more.
 
 #### Defined in
 
@@ -557,7 +557,7 @@ such as an E-Mail.
 
 If no `timestamp` is set, this field has no effect.
 
-View the [Timestamps](/react-native/docs/android/timers#timestamps) documentation to learn more.
+View the [Timestamps](/react-native/android/timers#timestamps) documentation to learn more.
 
 #### Defined in
 
@@ -571,7 +571,7 @@ View the [Timestamps](/react-native/docs/android/timers#timestamps) documentatio
 
 The small icon to show in the heads-up notification.
 
-View the [Icons](/react-native/docs/android/appearance#small-icons) documentation to learn
+View the [Icons](/react-native/android/appearance#small-icons) documentation to learn
 more.
 
 #### Defined in
@@ -603,7 +603,7 @@ different priorities in addition to providing sort key may cause this value to b
 
 If a `groupId` has been set, the sort key can also be used to order members of a notification group.
 
-View the [Android Grouping & Sorting](/react-native/docs/android/grouping-and-sorting#sorting)
+View the [Android Grouping & Sorting](/react-native/android/grouping-and-sorting#sorting)
 documentation to learn more.
 
 #### Defined in
@@ -623,7 +623,7 @@ The default value is to play no sound. To play the default system sound use 'def
 This setting has no behaviour on Android after API level version 26, instead you can set the
 sound on the notification channels.
 
-View the [Sound](/react-native/docs/android/behaviour#sound) documentation for more information.
+View the [Sound](/react-native/android/behaviour#sound) documentation for more information.
 
 #### Platform
 
@@ -643,7 +643,7 @@ Styled notifications provide users with more informative content and additional 
 
 Android supports different styles, however only one can be used with a notification.
 
-View the [Styles](/react-native/docs/android/styles) documentation to learn more
+View the [Styles](/react-native/android/styles) documentation to learn more
 view usage examples.
 
 #### Defined in
@@ -707,7 +707,7 @@ The timestamp can be used with other properties to change the behaviour of a not
 * Use with `showTimestamp` to show the timestamp to the users.
 * Use with `showChronometer` to create a on-going timer.
 
-View the [Timers](/react-native/docs/android/timers) documentation to learn more.
+View the [Timers](/react-native/android/timers) documentation to learn more.
 
 #### Defined in
 
@@ -721,7 +721,7 @@ View the [Timers](/react-native/docs/android/timers) documentation to learn more
 
 Sets the vibration pattern the notification uses when displayed. Must be an even amount of numbers.
 
-View the [Vibration](/react-native/docs/android/behaviour#vibration) documentation to learn more.
+View the [Vibration](/react-native/android/behaviour#vibration) documentation to learn more.
 
 #### Defined in
 
@@ -738,7 +738,7 @@ sensitive information (e.g. a banking app).
 
 Defaults to `AndroidVisibility.PRIVATE`.
 
-View the [Visibility](/react-native/docs/android/appearance#visibility) documentation to learn
+View the [Visibility](/react-native/android/appearance#visibility) documentation to learn
 more.
 
 #### Defined in

--- a/docs/react-native/reference/Interface.NotificationFullScreenAction.mdx
+++ b/docs/react-native/reference/Interface.NotificationFullScreenAction.mdx
@@ -1,0 +1,97 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NotificationFullScreenAction
+
+# Interface: NotificationFullScreenAction
+
+The interface used to describe a full-screen action for a notification.
+
+By setting a `fullScreenAction`, when the notification is displayed, it will launch a full-screen intent.
+
+On Android; when provided to a notification action, the action will only open you application if
+a `launchActivity` and/or a `mainComponent` is provided.
+
+Requires the following permission to be added to your `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+```
+
+Please see the [FullScreen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
+
+## Properties
+
+### id
+
+> **id**: `string`
+
+The unique ID for the action.
+
+The `id` property is used to differentiate between full-screen actions. When listening to notification
+events, the ID can be read from the `event.detail.notification.android.fullScreenAction` object.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:268](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L268)
+
+***
+
+### launchActivity?
+
+> `optional` **launchActivity**: `string`
+
+The custom Android Activity to launch on a full-screen action.
+
+This property can be used in advanced scenarios to launch a custom Android Activity when the user
+performs a full-screen action.
+
+View the [Android Full Screen](/react-native/docs/android/behaviour#full-screen) docs to learn more.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:280](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L280)
+
+***
+
+### launchActivityFlags?
+
+> `optional` **launchActivityFlags**: [`AndroidLaunchActivityFlag`](react-native/reference/Enumeration.AndroidLaunchActivityFlag)\[]
+
+Custom flags that are added to the Android [Intent](https://developer.android.com/reference/android/content/Intent.html) that launches your Activity.
+
+These are only required if you need to customise the behaviour of how your activities are launched; by default these are not required.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:289](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L289)
+
+***
+
+### mainComponent?
+
+> `optional` **mainComponent**: `string`
+
+A custom registered React component to launch on press action.
+
+This property can be used to open a custom React component when the notification is displayed.
+For this to correctly function on Android, a minor native code change is required.
+
+View the [Full-screen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:301](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L301)

--- a/docs/react-native/reference/Interface.NotificationFullScreenAction.mdx
+++ b/docs/react-native/reference/Interface.NotificationFullScreenAction.mdx
@@ -19,7 +19,7 @@ Requires the following permission to be added to your `AndroidManifest.xml`:
 <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 ```
 
-Please see the [FullScreen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
+Please see the [FullScreen Action](/react-native/android/behaviour#full-screen) document to learn more.
 
 ## Properties
 
@@ -47,7 +47,7 @@ The custom Android Activity to launch on a full-screen action.
 This property can be used in advanced scenarios to launch a custom Android Activity when the user
 performs a full-screen action.
 
-View the [Android Full Screen](/react-native/docs/android/behaviour#full-screen) docs to learn more.
+View the [Android Full Screen](/react-native/android/behaviour#full-screen) docs to learn more.
 
 #### Platform
 
@@ -86,7 +86,7 @@ A custom registered React component to launch on press action.
 This property can be used to open a custom React component when the notification is displayed.
 For this to correctly function on Android, a minor native code change is required.
 
-View the [Full-screen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
+View the [Full-screen Action](/react-native/android/behaviour#full-screen) document to learn more.
 
 #### Platform
 

--- a/docs/react-native/reference/Interface.NotificationIOS.mdx
+++ b/docs/react-native/reference/Interface.NotificationIOS.mdx
@@ -1,0 +1,240 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NotificationIOS
+
+# Interface: NotificationIOS
+
+The interface for iOS specific options which are applied to a notification.
+
+To learn more about iOS notifications, view the [iOS](/react-native/docs/iOS/introduction)
+documentation for full examples and usage.
+
+## Platform
+
+ios
+
+## Properties
+
+### attachments?
+
+> `optional` **attachments**: [`IOSNotificationAttachment`](react-native/reference/Interface.IOSNotificationAttachment)\[]
+
+Optional array of [IOSNotificationAttachment](/react-native/reference/iosnotificationattachment) interfaces.
+
+Attachments allow audio, image, or video content to be displayed with the notification, enriching the user's experience.
+
+View the [Attachments](/react-native/docs/ios/appearances#attachments) documentation for more information
+and usage examples.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:23](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L23)
+
+***
+
+### badgeCount?
+
+> `optional` **badgeCount**: `null` | `number`
+
+The application badge count number. Set to null to indicate no change, or 0 to hide.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:28](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L28)
+
+***
+
+### categoryId?
+
+> `optional` **categoryId**: `string`
+
+The id of a registered `IOSCategory` (via the `setNotificationCategories` API) that will be used to determine the
+appropriate actions to display for the notification.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:34](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L34)
+
+***
+
+### communicationInfo?
+
+> `optional` **communicationInfo**: [`IOSCommunicationInfo`](react-native/reference/Interface.IOSCommunicationInfo)
+
+Optional property for communication notifications
+
+#### Platform
+
+ios iOS >= 15
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:125](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L125)
+
+***
+
+### critical?
+
+> `optional` **critical**: `boolean`
+
+If the notification is a critical alert set this property to true; critical alerts will bypass
+the mute switch and also bypass Do Not Disturb.
+
+#### Platform
+
+ios iOS >= 12
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:64](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L64)
+
+***
+
+### criticalVolume?
+
+> `optional` **criticalVolume**: `number`
+
+The optional audio volume of the critical sound; a float value between 0.0 and 1.0.
+
+This property is not used unless the `critical: true` option is also set.
+
+#### Platform
+
+ios iOS >= 12
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:73](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L73)
+
+***
+
+### foregroundPresentationOptions?
+
+> `optional` **foregroundPresentationOptions**: [`IOSForegroundPresentationOptions`](react-native/reference/Interface.IOSForegroundPresentationOptions)
+
+Optional property to customise how notifications are presented when the app is in the foreground.
+
+By default, Notifee will show iOS notifications in heads-up mode if your app is currently in the foreground.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:118](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L118)
+
+***
+
+### interruptionLevel?
+
+> `optional` **interruptionLevel**: [`IOSNotificationInterruptionLevel`](react-native/reference/TypeAlias.IOSNotificationInterruptionLevel)
+
+Value that indicate the importance and delivery timing of a notification.
+
+#### Platform
+
+ios iOS >= 15
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:56](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L56)
+
+***
+
+### launchImageName?
+
+> `optional` **launchImageName**: `string`
+
+The launch image that will be used when the app is opened from this notification.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:39](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L39)
+
+***
+
+### sound?
+
+> `optional` **sound**: `string`
+
+The name of the sound file to be played. The sound must be in the Library/Sounds folder of the
+app's data container or the Library/Sounds folder of an app group data container.
+
+If the file is not found in a container, the system will look in the app's bundle.
+
+Use 'default' to use the default system sound.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:49](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L49)
+
+***
+
+### summaryArgument?
+
+> `optional` **summaryArgument**: `string`
+
+The argument that is inserted in the IOSCategory.summaryFormat for this notification.
+
+See `IOSCategory.summaryFormat`.
+
+#### Platform
+
+ios iOS >= 12
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:88](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L88)
+
+***
+
+### summaryArgumentCount?
+
+> `optional` **summaryArgumentCount**: `number`
+
+A number that indicates how many items in the summary are being represented.
+
+For example if a messages app sends one notification for 3 new messages in a group chat,
+the summaryArgument could be the name of the group chat and the summaryArgumentCount should be 3.
+
+If set, value cannot be 0 or less.
+
+See `IOSCategory.summaryFormat`.
+
+#### Platform
+
+ios iOS >= 12
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:102](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L102)
+
+***
+
+### targetContentId?
+
+> `optional` **targetContentId**: `string`
+
+The identifier for the window to be opened when the user taps a notification.
+
+This value determines the window brought forward when the user taps this notification on iPadOS.
+
+#### Platform
+
+ios iOS >= 13
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:111](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L111)
+
+***
+
+### threadId?
+
+> `optional` **threadId**: `string`
+
+A unique id for the thread or conversation related to this notification.
+This will be used to visually group notifications together.
+
+#### Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:79](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L79)

--- a/docs/react-native/reference/Interface.NotificationIOS.mdx
+++ b/docs/react-native/reference/Interface.NotificationIOS.mdx
@@ -8,7 +8,7 @@
 
 The interface for iOS specific options which are applied to a notification.
 
-To learn more about iOS notifications, view the [iOS](/react-native/docs/iOS/introduction)
+To learn more about iOS notifications, view the [iOS](/react-native/iOS/introduction)
 documentation for full examples and usage.
 
 ## Platform
@@ -25,7 +25,7 @@ Optional array of [IOSNotificationAttachment](/react-native/reference/iosnotific
 
 Attachments allow audio, image, or video content to be displayed with the notification, enriching the user's experience.
 
-View the [Attachments](/react-native/docs/ios/appearances#attachments) documentation for more information
+View the [Attachments](/react-native/ios/appearances#attachments) documentation for more information
 and usage examples.
 
 #### Defined in

--- a/docs/react-native/reference/Interface.NotificationPressAction.mdx
+++ b/docs/react-native/reference/Interface.NotificationPressAction.mdx
@@ -41,7 +41,7 @@ The custom Android Activity to launch on a press action.
 This property can be used in advanced scenarios to launch a custom Android Activity when the user
 performs a press action.
 
-View the [Android Interaction](/react-native/docs/android/interaction) docs to learn more.
+View the [Android Interaction](/react-native/android/interaction) docs to learn more.
 
 #### Platform
 
@@ -80,7 +80,7 @@ A custom registered React component to launch on press action.
 This property can be used to open a custom React component when the user performs a press action.
 For this to correctly function on Android, a minor native code change is required.
 
-View the [Press Action](/react-native/docs/android/interaction#press-action) document to learn more.
+View the [Press Action](/react-native/android/interaction#press-action) document to learn more.
 
 #### Platform
 

--- a/docs/react-native/reference/Interface.NotificationPressAction.mdx
+++ b/docs/react-native/reference/Interface.NotificationPressAction.mdx
@@ -1,0 +1,91 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NotificationPressAction
+
+# Interface: NotificationPressAction
+
+The interface used to describe a press action for a notification.
+
+There are various ways a user can interact with a notification, the most common being pressing
+the notification, pressing an action or providing text input. This interface defines what happens
+when a user performs such interaction.
+
+On Android; when provided to a notification action, the action will only open you application if
+a `launchActivity` and/or a `mainComponent` is provided.
+
+## Properties
+
+### id
+
+> **id**: `string`
+
+The unique ID for the action.
+
+The `id` property is used to differentiate between user press actions. When listening to notification
+events, the ID can be read from the `event.detail.pressAction` object.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:210](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L210)
+
+***
+
+### launchActivity?
+
+> `optional` **launchActivity**: `string`
+
+The custom Android Activity to launch on a press action.
+
+This property can be used in advanced scenarios to launch a custom Android Activity when the user
+performs a press action.
+
+View the [Android Interaction](/react-native/docs/android/interaction) docs to learn more.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:222](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L222)
+
+***
+
+### launchActivityFlags?
+
+> `optional` **launchActivityFlags**: [`AndroidLaunchActivityFlag`](react-native/reference/Enumeration.AndroidLaunchActivityFlag)\[]
+
+Custom flags that are added to the Android [Intent](https://developer.android.com/reference/android/content/Intent.html) that launches your Activity.
+
+These are only required if you need to customise the behaviour of how your activities are launched; by default these are not required.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:231](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L231)
+
+***
+
+### mainComponent?
+
+> `optional` **mainComponent**: `string`
+
+A custom registered React component to launch on press action.
+
+This property can be used to open a custom React component when the user performs a press action.
+For this to correctly function on Android, a minor native code change is required.
+
+View the [Press Action](/react-native/docs/android/interaction#press-action) document to learn more.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:243](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L243)

--- a/docs/react-native/reference/Interface.NotificationSettings.mdx
+++ b/docs/react-native/reference/Interface.NotificationSettings.mdx
@@ -1,0 +1,59 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / NotificationSettings
+
+# Interface: NotificationSettings
+
+## Properties
+
+### android
+
+> **android**: [`AndroidNotificationSettings`](react-native/reference/Interface.AndroidNotificationSettings)
+
+Overall notification settings for the application in android.
+On non-Android platforms, this will be populated with default values
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:512](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L512)
+
+***
+
+### authorizationStatus
+
+> **authorizationStatus**: [`AuthorizationStatus`](react-native/reference/Enumeration.AuthorizationStatus)
+
+Overall notification authorization status for the application.
+On Android, `authorizationStatus` will return only either `AuthorizationStatus.DENIED` or `AuthorizationStatus.AUTHORIZED`.
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:502](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L502)
+
+***
+
+### ios
+
+> **ios**: [`IOSNotificationSettings`](react-native/reference/Interface.IOSNotificationSettings)
+
+Overall notification settings for the application in iOS.
+On non-iOS platforms, this will be populated with default values
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:507](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L507)
+
+***
+
+### web
+
+> **web**: `WebNotificationSettings`
+
+Overall notification settings for the application in web.
+On non-Web platforms, this will be populated with default values
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:517](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L517)

--- a/docs/react-native/reference/Interface.TimestampTrigger.mdx
+++ b/docs/react-native/reference/Interface.TimestampTrigger.mdx
@@ -1,0 +1,71 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / TimestampTrigger
+
+# Interface: TimestampTrigger
+
+Interface for building a trigger with a timestamp.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+
+## Properties
+
+### alarmManager?
+
+> `optional` **alarmManager**: `boolean` | [`TimestampTriggerAlarmManager`](react-native/reference/Interface.TimestampTriggerAlarmManager)
+
+Choose to schedule your trigger notification with Android's AlarmManager API.
+
+By default, trigger notifications are created with Android's WorkManager API.
+
+#### Platform
+
+android
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:34](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L34)
+
+***
+
+### repeatFrequency?
+
+> `optional` **repeatFrequency**: [`RepeatFrequency`](react-native/reference/Enumeration.RepeatFrequency)
+
+The frequency at which the trigger repeats.
+If unset, the notification will only be displayed once.
+
+For example:
+if set to `RepeatFrequency.HOURLY`, the notification will repeat every hour from the timestamp specified.
+if set to `RepeatFrequency.DAILY`, the notification will repeat every day from the timestamp specified.
+if set to `RepeatFrequency.WEEKLY`, the notification will repeat every week from the timestamp specified.
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:25](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L25)
+
+***
+
+### timestamp
+
+> **timestamp**: `number`
+
+The timestamp when the notification should first be shown, in milliseconds since 1970.
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:14](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L14)
+
+***
+
+### type
+
+> **type**: [`TIMESTAMP`](react-native/reference/Enumeration.TriggerType#timestamp)
+
+Constant enum value used to identify the trigger type.
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:10](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L10)

--- a/docs/react-native/reference/Interface.TimestampTrigger.mdx
+++ b/docs/react-native/reference/Interface.TimestampTrigger.mdx
@@ -8,7 +8,7 @@
 
 Interface for building a trigger with a timestamp.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+View the [Triggers](/react-native/triggers) documentation to learn more.
 
 ## Properties
 

--- a/docs/react-native/reference/Interface.TimestampTriggerAlarmManager.mdx
+++ b/docs/react-native/reference/Interface.TimestampTriggerAlarmManager.mdx
@@ -8,7 +8,7 @@
 
 Interface to specify additional options for the AlarmManager which can be used with `TimestampTrigger.alarmManager`.
 
-View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+View the [Triggers](/react-native/triggers) documentation to learn more.
 
 ## Platform
 

--- a/docs/react-native/reference/Interface.TimestampTriggerAlarmManager.mdx
+++ b/docs/react-native/reference/Interface.TimestampTriggerAlarmManager.mdx
@@ -1,0 +1,45 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / TimestampTriggerAlarmManager
+
+# Interface: TimestampTriggerAlarmManager
+
+Interface to specify additional options for the AlarmManager which can be used with `TimestampTrigger.alarmManager`.
+
+View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+
+## Platform
+
+android
+
+## Properties
+
+### ~~allowWhileIdle?~~
+
+> `optional` **allowWhileIdle**: `boolean`
+
+#### Deprecated
+
+## use `type` instead
+
+Sets whether your trigger notification should be displayed even when the system is in low-power idle modes.
+
+Defaults to `false`.
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:66](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L66)
+
+***
+
+### type?
+
+> `optional` **type**: [`AlarmType`](react-native/reference/Enumeration.AlarmType)
+
+The type of alarm set by alarm manager of android
+
+#### Defined in
+
+[packages/react-native/src/types/Trigger.ts:69](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L69)

--- a/docs/react-native/reference/Interface.TriggerNotification.mdx
+++ b/docs/react-native/reference/Interface.TriggerNotification.mdx
@@ -1,0 +1,33 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / TriggerNotification
+
+# Interface: TriggerNotification
+
+An interface representing a notification that is pending.
+
+## Properties
+
+### notification
+
+> **notification**: [`Notification`](react-native/reference/Interface.Notification)
+
+The notification
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:155](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L155)
+
+***
+
+### trigger
+
+> **trigger**: [`Trigger`](react-native/reference/TypeAlias.Trigger)
+
+The trigger that is used to schedule the notification
+
+#### Defined in
+
+[packages/react-native/src/types/Notification.ts:160](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L160)

--- a/docs/react-native/reference/TypeAlias.ForegroundServiceTask.mdx
+++ b/docs/react-native/reference/TypeAlias.ForegroundServiceTask.mdx
@@ -12,7 +12,7 @@ A representation of a Foreground Service task registered via [`registerForegroun
 
 The task must resolve a promise once complete, and in turn removes the notification.
 
-View the [Foreground Service](/react-native/docs/android/foreground-service) documentation to
+View the [Foreground Service](/react-native/android/foreground-service) documentation to
 learn more.
 
 ## Parameters

--- a/docs/react-native/reference/TypeAlias.ForegroundServiceTask.mdx
+++ b/docs/react-native/reference/TypeAlias.ForegroundServiceTask.mdx
@@ -1,0 +1,34 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / ForegroundServiceTask
+
+# Type Alias: ForegroundServiceTask()
+
+> **ForegroundServiceTask**: (`notification`) => `Promise`\<`void`>
+
+A representation of a Foreground Service task registered via [`registerForegroundService`](/react-native/reference/registerforegroundservice).
+
+The task must resolve a promise once complete, and in turn removes the notification.
+
+View the [Foreground Service](/react-native/docs/android/foreground-service) documentation to
+learn more.
+
+## Parameters
+
+### notification
+
+[`Notification`](react-native/reference/Interface.Notification)
+
+## Returns
+
+`Promise`\<`void`>
+
+## Platform
+
+android
+
+## Defined in
+
+[packages/react-native/src/types/Notification.ts:191](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Notification.ts#L191)

--- a/docs/react-native/reference/TypeAlias.IOSNotificationInterruptionLevel.mdx
+++ b/docs/react-native/reference/TypeAlias.IOSNotificationInterruptionLevel.mdx
@@ -1,0 +1,20 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / IOSNotificationInterruptionLevel
+
+# Type Alias: IOSNotificationInterruptionLevel
+
+> **IOSNotificationInterruptionLevel**: `"active"` | `"critical"` | `"passive"` | `"timeSensitive"`
+
+Constants that indicate the importance and delivery timing of a notification.
+[https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel](https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel)
+
+## Platform
+
+ios
+
+## Defined in
+
+[packages/react-native/src/types/NotificationIOS.ts:683](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/NotificationIOS.ts#L683)

--- a/docs/react-native/reference/TypeAlias.Trigger.mdx
+++ b/docs/react-native/reference/TypeAlias.Trigger.mdx
@@ -1,0 +1,13 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / Trigger
+
+# Type Alias: Trigger
+
+> **Trigger**: [`TimestampTrigger`](react-native/reference/Interface.TimestampTrigger) | [`IntervalTrigger`](react-native/reference/Interface.IntervalTrigger)
+
+## Defined in
+
+[packages/react-native/src/types/Trigger.ts:136](https://github.com/invertase/notifee/blob/main/packages/react-native/src/types/Trigger.ts#L136)

--- a/docs/react-native/reference/Variable.default.mdx
+++ b/docs/react-native/reference/Variable.default.mdx
@@ -1,0 +1,13 @@
+[**@notifee/react-native**](react-native/reference/index)
+
+***
+
+[@notifee/react-native](react-native/reference/index) / default
+
+# Variable: default
+
+> `const` **default**: `ModuleWithStatics`
+
+## Defined in
+
+[packages/react-native/src/index.ts:26](https://github.com/invertase/notifee/blob/main/packages/react-native/src/index.ts#L26)

--- a/docs/react-native/reference/index.mdx
+++ b/docs/react-native/reference/index.mdx
@@ -1,0 +1,81 @@
+**@notifee/react-native**
+
+***
+
+# @notifee/react-native
+
+## Enumerations
+
+* [AlarmType](react-native/reference/Enumeration.AlarmType)
+* [AndroidBadgeIconType](react-native/reference/Enumeration.AndroidBadgeIconType)
+* [AndroidCategory](react-native/reference/Enumeration.AndroidCategory)
+* [AndroidColor](react-native/reference/Enumeration.AndroidColor)
+* [AndroidDefaults](react-native/reference/Enumeration.AndroidDefaults)
+* [AndroidFlags](react-native/reference/Enumeration.AndroidFlags)
+* [AndroidForegroundServiceType](react-native/reference/Enumeration.AndroidForegroundServiceType)
+* [AndroidGroupAlertBehavior](react-native/reference/Enumeration.AndroidGroupAlertBehavior)
+* [AndroidImportance](react-native/reference/Enumeration.AndroidImportance)
+* [AndroidLaunchActivityFlag](react-native/reference/Enumeration.AndroidLaunchActivityFlag)
+* [AndroidNotificationSetting](react-native/reference/Enumeration.AndroidNotificationSetting)
+* [AndroidStyle](react-native/reference/Enumeration.AndroidStyle)
+* [AndroidVisibility](react-native/reference/Enumeration.AndroidVisibility)
+* [AuthorizationStatus](react-native/reference/Enumeration.AuthorizationStatus)
+* [EventType](react-native/reference/Enumeration.EventType)
+* [IOSIntentIdentifier](react-native/reference/Enumeration.IOSIntentIdentifier)
+* [IOSNotificationSetting](react-native/reference/Enumeration.IOSNotificationSetting)
+* [IOSShowPreviewsSetting](react-native/reference/Enumeration.IOSShowPreviewsSetting)
+* [RepeatFrequency](react-native/reference/Enumeration.RepeatFrequency)
+* [TimeUnit](react-native/reference/Enumeration.TimeUnit)
+* [TriggerType](react-native/reference/Enumeration.TriggerType)
+
+## Interfaces
+
+* [AndroidAction](react-native/reference/Interface.AndroidAction)
+* [AndroidBigPictureStyle](react-native/reference/Interface.AndroidBigPictureStyle)
+* [AndroidBigTextStyle](react-native/reference/Interface.AndroidBigTextStyle)
+* [AndroidChannel](react-native/reference/Interface.AndroidChannel)
+* [AndroidChannelGroup](react-native/reference/Interface.AndroidChannelGroup)
+* [AndroidInboxStyle](react-native/reference/Interface.AndroidInboxStyle)
+* [AndroidInput](react-native/reference/Interface.AndroidInput)
+* [AndroidMessagingStyle](react-native/reference/Interface.AndroidMessagingStyle)
+* [AndroidMessagingStyleMessage](react-native/reference/Interface.AndroidMessagingStyleMessage)
+* [AndroidNotificationSettings](react-native/reference/Interface.AndroidNotificationSettings)
+* [AndroidPerson](react-native/reference/Interface.AndroidPerson)
+* [AndroidProgress](react-native/reference/Interface.AndroidProgress)
+* [DisplayedNotification](react-native/reference/Interface.DisplayedNotification)
+* [Event](react-native/reference/Interface.Event)
+* [EventDetail](react-native/reference/Interface.EventDetail)
+* [InitialNotification](react-native/reference/Interface.InitialNotification)
+* [IntervalTrigger](react-native/reference/Interface.IntervalTrigger)
+* [IOSAttachmentThumbnailClippingRect](react-native/reference/Interface.IOSAttachmentThumbnailClippingRect)
+* [IOSCommunicationInfo](react-native/reference/Interface.IOSCommunicationInfo)
+* [IOSCommunicationInfoPerson](react-native/reference/Interface.IOSCommunicationInfoPerson)
+* [IOSForegroundPresentationOptions](react-native/reference/Interface.IOSForegroundPresentationOptions)
+* [IOSInput](react-native/reference/Interface.IOSInput)
+* [IOSNotificationAttachment](react-native/reference/Interface.IOSNotificationAttachment)
+* [IOSNotificationCategory](react-native/reference/Interface.IOSNotificationCategory)
+* [IOSNotificationCategoryAction](react-native/reference/Interface.IOSNotificationCategoryAction)
+* [IOSNotificationPermissions](react-native/reference/Interface.IOSNotificationPermissions)
+* [IOSNotificationSettings](react-native/reference/Interface.IOSNotificationSettings)
+* [NativeAndroidChannel](react-native/reference/Interface.NativeAndroidChannel)
+* [NativeAndroidChannelGroup](react-native/reference/Interface.NativeAndroidChannelGroup)
+* [NativeError](react-native/reference/Interface.NativeError)
+* [Notification](react-native/reference/Interface.Notification)
+* [NotificationAndroid](react-native/reference/Interface.NotificationAndroid)
+* [NotificationFullScreenAction](react-native/reference/Interface.NotificationFullScreenAction)
+* [NotificationIOS](react-native/reference/Interface.NotificationIOS)
+* [NotificationPressAction](react-native/reference/Interface.NotificationPressAction)
+* [NotificationSettings](react-native/reference/Interface.NotificationSettings)
+* [TimestampTrigger](react-native/reference/Interface.TimestampTrigger)
+* [TimestampTriggerAlarmManager](react-native/reference/Interface.TimestampTriggerAlarmManager)
+* [TriggerNotification](react-native/reference/Interface.TriggerNotification)
+
+## Type Aliases
+
+* [ForegroundServiceTask](react-native/reference/TypeAlias.ForegroundServiceTask)
+* [IOSNotificationInterruptionLevel](react-native/reference/TypeAlias.IOSNotificationInterruptionLevel)
+* [Trigger](react-native/reference/TypeAlias.Trigger)
+
+## Variables
+
+* [default](react-native/reference/Variable.default)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lerna:bootstrap": "lerna bootstrap",
     "lerna:link": "lerna link && lerna exec -- yarn link",
     "lerna:clean": "lerna clean",
-    "gen:reference": "rimraf docs/typedoc.json docs/typedoc.min.json && node scripts/generate-typedoc.js",
+    "gen:reference": "yarn typedoc",
     "test:all": "yarn test:core:android && yarn tests_rn:test && yarn tests_rn:android:test && yarn tests_rn:ios:test",
     "test:core:android": "cd android && ./gradlew testDebugUnit",
     "tests_rn:packager": "cd tests_react_native && npx react-native start",
@@ -73,9 +73,12 @@
     "google-java-format": "^1.4.0",
     "lerna": "^4.0.0",
     "prettier": "^2.5.1",
+    "remark-link-rewrite": "^1.0.7",
     "rimraf": "^3.0.2",
     "semantic-release": "^24.2.0",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.27.5",
+    "typedoc-plugin-markdown": "^4.3.3",
+    "typedoc-plugin-remark": "^1.2.1",
     "typescript": "^4.6.2"
   },
   "resolutions": {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -12,7 +12,7 @@
     "build:clean": "rimraf android/libs && rimraf android/build && rimraf ios/build && rimraf dist",
     "build:watch": "tsc --watch",
     "prepare": "yarn run build",
-    "prepublishOnly": "cd ../.. && yarn run build:core",
+    "prepublishOnly": "cd ../.. && yarn run build:core && yarn gen:reference",
     "format:android": "google-java-format --replace -i $(find . -type f -name \"*.java\" ! -path \"*/node_modules/*\" ! -path \"*/generated/*\")",
     "format:android:check": "google-java-format --set-exit-if-changed --replace -i $(find . -type f -name \"*.java\" ! -path \"*/node_modules/*\" ! -path \"*/generated/*\")",
     "format:ios": "npm_config_yes=true npx clang-format -i --glob=\"ios/**/*.{h,cpp,m,mm}\" --style=Google",

--- a/packages/react-native/src/types/Module.ts
+++ b/packages/react-native/src/types/Module.ts
@@ -21,7 +21,7 @@ export interface Module {
    * The `cancelAllNotifications` API removes any displayed notifications from the users device and
    * any pending trigger notifications.
    *
-   * This method does not cancel Android [Foreground Service](/react-native/docs/android/foreground-service)
+   * This method does not cancel Android [Foreground Service](/react-native/android/foreground-service)
    * notifications.
    * @param notificationIds An array of notifications IDs. This is automatically generated and returned
    * when creating a notification, or has been set manually via the `id` property.
@@ -33,7 +33,7 @@ export interface Module {
   /**
    * API used to cancel any displayed notifications.
    *
-   * This method does not cancel Android [Foreground Service](/react-native/docs/android/foreground-service)
+   * This method does not cancel Android [Foreground Service](/react-native/android/foreground-service)
    * notifications.
    */
   cancelDisplayedNotifications(notificationIds?: string[]): Promise<void>;
@@ -49,7 +49,7 @@ export interface Module {
    * The `cancelNotification` API removes any displayed notifications or ones with triggers
    * set for the specified ID.
    *
-   * This method does not cancel [Foreground Service](/react-native/docs/android/foreground-service)
+   * This method does not cancel [Foreground Service](/react-native/android/foreground-service)
    * notifications.
    *
    * @param notificationId The unique notification ID. This is automatically generated and returned
@@ -63,7 +63,7 @@ export interface Module {
    * API used to cancel a single displayed notification.
    *
    *
-   * This method does not cancel [Foreground Service](/react-native/docs/android/foreground-service)
+   * This method does not cancel [Foreground Service](/react-native/android/foreground-service)
    * notifications.
    *
    * @param notificationId The unique notification ID. This is automatically generated and returned
@@ -94,7 +94,7 @@ export interface Module {
    *
    * The channel ID is returned once the operation has completed.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    * @param channel The [`AndroidChannel`](/react-native/reference/androidchannel) interface used to create/update a group.
@@ -124,7 +124,7 @@ export interface Module {
    *
    * The channel group ID is returned once the operation has completed.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    * @param channelGroup The [`AndroidChannelGroup`](/react-native/reference/androidchannelgroup)
@@ -151,7 +151,7 @@ export interface Module {
    *
    * > When a channel is deleted, notifications assigned to that channel will fail to display.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    * @param channelId The unique channel ID to delete.
@@ -167,7 +167,7 @@ export interface Module {
    * Deleting a group does not delete channels which are assigned to the group, they will instead be
    * unassigned the group and continue to function as expected.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    * @param channelGroupId The unique channel group ID to delete.
@@ -180,7 +180,7 @@ export interface Module {
    * This API is used to display a notification on the users device. All
    * channels/categories should be created before triggering this method during the apps lifecycle.
    *
-   * View the [Displaying a Notification](/react-native/docs/displaying-a-notification)
+   * View the [Displaying a Notification](/react-native/displaying-a-notification)
    * documentation for more information.
    *
    * @param notification The [`Notification`](/react-native/reference/notification) interface used
@@ -194,7 +194,7 @@ export interface Module {
    * On Android >= 12 / API >= 31, the alarm special access settings screen is displayed, otherwise,
    * this is a no-op & instantly resolves.
    *
-   * View the [Trigger](/react-native/docs/android/triggers#android-12-limitations) documentation for more information.
+   * View the [Trigger](/react-native/android/triggers#android-12-limitations) documentation for more information.
    *
    * @platform android
    */
@@ -205,7 +205,7 @@ export interface Module {
    *
    * All channels/categories should be created before calling this method during the apps lifecycle.
    *
-   * View the [Triggers](/react-native/docs/triggers) documentation for more information.
+   * View the [Triggers](/react-native/triggers) documentation for more information.
    *
    * @param notification The [`Notification`](/react-native/reference/notification) interface used
    * to create a notification.
@@ -218,7 +218,7 @@ export interface Module {
   /**
    * API used to return the ids of trigger notifications that are pending.
    *
-   * View the [Triggers](/react-native/docs/triggers) documentation for more information.
+   * View the [Triggers](/react-native/triggers) documentation for more information.
    */
   getTriggerNotificationIds(): Promise<string[]>;
 
@@ -242,7 +242,7 @@ export interface Module {
    * retrieved from the device. View the [`NativeAndroidChannel`](/react-native/reference/nativeandroidchannel)
    * documentation for more information.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    * @param channelId The channel ID created with [`createChannel`](/react-native/reference/createchannel). If
@@ -278,7 +278,7 @@ export interface Module {
    * retrieved from the device. View the [`NativeAndroidChannel`](/react-native/reference/nativeandroidchannel)
    * documentation for more information.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    */
@@ -294,7 +294,7 @@ export interface Module {
    * retrieved from the device. View the [`NativeAndroidChannelGroup`](/react-native/reference/nativeandroidchannelgroup)
    * documentation for more information.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    * @param channelGroupId The channel ID created with [`createChannelGroup`](/react-native/reference/createchannelgroup). If
@@ -312,7 +312,7 @@ export interface Module {
    * retrieved from the device. View the [`NativeAndroidChannelGroup`](/react-native/reference/nativeandroidchannelgroup)
    * documentation for more information.
    *
-   * View the [Channels & Groups](/react-native/docs/android/channels) documentation for more information.
+   * View the [Channels & Groups](/react-native/android/channels) documentation for more information.
    *
    * @platform android
    */
@@ -327,7 +327,7 @@ export interface Module {
    * Once the initial notification has been consumed by this API, it is removed and will no longer
    * be available. It will also be removed if the user relaunches the application.
    *
-   * View the [App open events](/react-native/docs/events#app-open-events) documentation for more
+   * View the [App open events](/react-native/events#app-open-events) documentation for more
    * information and example usage.
    *
    * Deprecated for iOS in favour of `onForegroundEvent` - you can still use this method on iOS
@@ -342,7 +342,7 @@ export interface Module {
    * to send events. The handler must return a Promise once complete and only a single event handler
    * can be registered for the application.
    *
-   * View the [Background events](/react-native/docs/events#background-events) documentation for more
+   * View the [Background events](/react-native/events#background-events) documentation for more
    * information and example usage.
    *
    * To listen to foreground events, see the [`onForegroundEvent`](/react-native/reference/onforegroundevent) documentation.
@@ -359,7 +359,7 @@ export interface Module {
    * to send events. Multiple foreground observers can be registered throughout the applications
    * lifecycle. The method returns a function, used to unsubscribe from further events,
    *
-   * View the [Foreground events](/react-native/docs/events#foreground-events) documentation for more
+   * View the [Foreground events](/react-native/events#foreground-events) documentation for more
    * information and example usage.
    *
    * To listen to background events, see the [`onBackgroundEvent`](/react-native/reference/onbackgroundevent) documentation.
@@ -399,7 +399,7 @@ export interface Module {
    * Only a single foreground service can exist for the application, and calling this method more
    * than once will update the existing task runner.
    *
-   * View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for
+   * View the [Foreground Service](/react-native/android/foreground-service) documentation for
    * more information.
    *
    * @platform android
@@ -519,7 +519,7 @@ export interface Module {
    * If the API version is >= 23, the battery optimization settings screen is displayed, otherwise,
    * this is a no-op & instantly resolves.
    *
-   * View the [Background Restrictions](/react-native/docs/android/behaviour#background-restrictions) documentation for more information.
+   * View the [Background Restrictions](/react-native/android/behaviour#background-restrictions) documentation for more information.
    *
    * @platform android
    */
@@ -530,7 +530,7 @@ export interface Module {
    *
    * Supports API versions >= 23.
    *
-   * View the [Background Restrictions](/react-native/docs/android/behaviour#background-restrictions) documentation for more information.
+   * View the [Background Restrictions](/react-native/android/behaviour#background-restrictions) documentation for more information.
    *
    * @platform android
    */
@@ -543,7 +543,7 @@ export interface Module {
    *
    * On iOS, an instance of `PowerManagerInfo` will be returned with `activity` set to `null`.
    *
-   * View the [Background Restrictions](/react-native/docs/android/background-restrictions) documentation for more information.
+   * View the [Background Restrictions](/react-native/android/background-restrictions) documentation for more information.
    *
    * ```js
    * import notifee from `@notifee/react-native`;
@@ -568,7 +568,7 @@ export interface Module {
    *
    * Call `getPowerManagerInfo()` first to find out if the user's device is supported.
    *
-   * View the [Background Restrictions](/react-native/docs/android/background-restrictions) documentation for more information.
+   * View the [Background Restrictions](/react-native/android/background-restrictions) documentation for more information.
    *
    * ```js
    * import notifee from `@notifee/react-native`;

--- a/packages/react-native/src/types/Notification.ts
+++ b/packages/react-native/src/types/Notification.ts
@@ -15,7 +15,7 @@ import { WebNotificationSettings } from './NotificationWeb';
 /**
  * Interface for building a local notification for both Android & iOS devices.
  *
- * To learn more about displaying a notification, view the [Displaying a Notification](/react-native/docs/displaying-a-notification)
+ * To learn more about displaying a notification, view the [Displaying a Notification](/react-native/displaying-a-notification)
  * documentation.
  *
  */
@@ -85,7 +85,7 @@ export interface Notification {
 /**
  * An interface representing a notification & action that launched the current app / or Android activity.
  *
- * View the [App open events](/react-native/docs/events#app-open-events) documentation to learn more.
+ * View the [App open events](/react-native/events#app-open-events) documentation to learn more.
  *
  * This interface is returned from [`getInitialNotification`](/react-native/reference/getinitialnotification) when
  * an initial notification is available.
@@ -163,7 +163,7 @@ export interface TriggerNotification {
 /**
  * An interface representing a Notifee event.
  *
- * View the [Events](/react-native/docs/events) documentation to learn more about foreground and
+ * View the [Events](/react-native/events) documentation to learn more about foreground and
  * background events.
  */
 export interface Event {
@@ -183,7 +183,7 @@ export interface Event {
  *
  * The task must resolve a promise once complete, and in turn removes the notification.
  *
- * View the [Foreground Service](/react-native/docs/android/foreground-service) documentation to
+ * View the [Foreground Service](/react-native/android/foreground-service) documentation to
  * learn more.
  *
  * @platform android
@@ -215,7 +215,7 @@ export interface NotificationPressAction {
    * This property can be used in advanced scenarios to launch a custom Android Activity when the user
    * performs a press action.
    *
-   * View the [Android Interaction](/react-native/docs/android/interaction) docs to learn more.
+   * View the [Android Interaction](/react-native/android/interaction) docs to learn more.
    *
    * @platform android
    */
@@ -236,7 +236,7 @@ export interface NotificationPressAction {
    * This property can be used to open a custom React component when the user performs a press action.
    * For this to correctly function on Android, a minor native code change is required.
    *
-   * View the [Press Action](/react-native/docs/android/interaction#press-action) document to learn more.
+   * View the [Press Action](/react-native/android/interaction#press-action) document to learn more.
    *
    * @platform android
    */
@@ -256,7 +256,7 @@ export interface NotificationPressAction {
  * <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
  * ```
  *
- * Please see the [FullScreen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
+ * Please see the [FullScreen Action](/react-native/android/behaviour#full-screen) document to learn more.
  */
 export interface NotificationFullScreenAction {
   /**
@@ -273,7 +273,7 @@ export interface NotificationFullScreenAction {
    * This property can be used in advanced scenarios to launch a custom Android Activity when the user
    * performs a full-screen action.
    *
-   * View the [Android Full Screen](/react-native/docs/android/behaviour#full-screen) docs to learn more.
+   * View the [Android Full Screen](/react-native/android/behaviour#full-screen) docs to learn more.
    *
    * @platform android
    */
@@ -294,7 +294,7 @@ export interface NotificationFullScreenAction {
    * This property can be used to open a custom React component when the notification is displayed.
    * For this to correctly function on Android, a minor native code change is required.
    *
-   * View the [Full-screen Action](/react-native/docs/android/behaviour#full-screen) document to learn more.
+   * View the [Full-screen Action](/react-native/android/behaviour#full-screen) document to learn more.
    *
    * @platform android
    */
@@ -304,7 +304,7 @@ export interface NotificationFullScreenAction {
 /**
  * An enum representing an event type, defined on [`Event`](/react-native/reference/event).
  *
- * View the [Events](/react-native/docs/events) documentation to learn more about foreground and
+ * View the [Events](/react-native/events) documentation to learn more about foreground and
  * background events.
  */
 export enum EventType {
@@ -387,7 +387,7 @@ export enum EventType {
 /**
  * An interface representing the different detail values which can be provided with a notification event.
  *
- * View the [Events](/react-native/docs/events) documentation to learn more.
+ * View the [Events](/react-native/events) documentation to learn more.
  */
 export interface EventDetail {
   /**

--- a/packages/react-native/src/types/NotificationAndroid.ts
+++ b/packages/react-native/src/types/NotificationAndroid.ts
@@ -7,7 +7,7 @@ import { NotificationPressAction, NotificationFullScreenAction } from './Notific
 /**
  * The interface for Android specific options which are applied to a notification.
  *
- * To learn more about Android notifications, view the [Android](/react-native/docs/android/introduction)
+ * To learn more about Android notifications, view the [Android](/react-native/android/introduction)
  * documentation for full examples and usage.
  *
  * @platform android
@@ -19,7 +19,7 @@ export interface NotificationAndroid {
    * Adds quick actions to a notification. Quick Actions enable users to interact with your application
    * directly from the notification body, providing an overall greater user experience.
    *
-   * View the [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation for more information.
+   * View the [Quick Actions](/react-native/android/interaction#quick-actions) documentation for more information.
    */
   actions?: AndroidAction[];
 
@@ -33,7 +33,7 @@ export interface NotificationAndroid {
    * Ensure a foreground service runner function has been provided to `registerForegroundService`.
    * Without one, the notification will not be displayed.
    *
-   * View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for more information.
+   * View the [Foreground Service](/react-native/android/foreground-service) documentation for more information.
    *
    * Defaults to `false`.
    */
@@ -71,7 +71,7 @@ export interface NotificationAndroid {
   /**
    * Sets the type of badge used when the notification is being displayed in badge mode.
    *
-   * View the [Badges](/react-native/docs/android/appearance#badges) documentation for more information
+   * View the [Badges](/react-native/android/appearance#badges) documentation for more information
    * and usage examples.
    *
    * Defaults to `AndroidBadgeIconType.LARGE`.
@@ -92,7 +92,7 @@ export interface NotificationAndroid {
    * Specifies the `AndroidChannel` which the notification will be delivered on.
    *
    * On Android 8.0 (API 26) the channel ID is required. Providing a invalid channel ID will throw
-   * an error. View the [Channels & Groups](/react-native/docs/android/channels) documentation for
+   * an error. View the [Channels & Groups](/react-native/android/channels) documentation for
    * more information and usage examples.
    */
   channelId?: string;
@@ -103,7 +103,7 @@ export interface NotificationAndroid {
    *
    * The color can be a predefined system `AndroidColor` or [hexadecimal](https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4).
    *
-   * View the [Color](/react-native/docs/android/appearance#color) documentation for more information.
+   * View the [Color](/react-native/android/appearance#color) documentation for more information.
    */
   color?: AndroidColor | string;
 
@@ -115,7 +115,7 @@ export interface NotificationAndroid {
    * This should only be used for high priority ongoing tasks like navigation, an ongoing call,
    * or other similarly high-priority events for the user.
    *
-   * View the [Foreground Service](/react-native/docs/android/foreground-service) documentation for more information.
+   * View the [Foreground Service](/react-native/android/foreground-service) documentation for more information.
    *
    * Defaults to `false`.
    */
@@ -148,7 +148,7 @@ export interface NotificationAndroid {
    *
    * On some devices, the system may automatically group notifications.
    *
-   * View the [Android Grouping & Sorting guide](/react-native/docs/android/grouping-and-sorting) documentation to
+   * View the [Android Grouping & Sorting guide](/react-native/android/grouping-and-sorting) documentation to
    * learn more.
    */
   groupId?: string;
@@ -160,7 +160,7 @@ export interface NotificationAndroid {
    * you want to mute. For example, if you want only the summary of your group to make noise, all
    * children in the group should have the group alert behavior `AndroidGroupAlertBehavior.SUMMARY`.
    *
-   * View the [Android Grouping & Sorting guide](/react-native/docs/android/grouping-and-sorting#group-behaviour)
+   * View the [Android Grouping & Sorting guide](/react-native/android/grouping-and-sorting#group-behaviour)
    * documentation to learn more.
    */
   groupAlertBehavior?: AndroidGroupAlertBehavior;
@@ -190,7 +190,7 @@ export interface NotificationAndroid {
    *
    * Sets a large icon on the notification.
    *
-   * View the [Android Appearance](/react-native/docs/android/appearance#large-icons) documentation to learn
+   * View the [Android Appearance](/react-native/android/appearance#large-icons) documentation to learn
    * more about this property.
    */
   largeIcon?: string | number | object;
@@ -211,7 +211,7 @@ export interface NotificationAndroid {
    * along with the number of milliseconds to show the light, and the number of milliseconds to
    * turn off the light. The light frequency pattern is repeated.
    *
-   * View the [Lights](/react-native/docs/android/behaviour#lights) documentation for more information.
+   * View the [Lights](/react-native/android/behaviour#lights) documentation for more information.
    */
   lights?: [AndroidColor | string, number, number];
 
@@ -234,7 +234,7 @@ export interface NotificationAndroid {
    * - Ongoing notifications are sorted above the regular notifications in the notification panel.
    * - Ongoing notifications do not have an 'X' close button, and are not affected by the "Clear all" button.
    *
-   * View the [Ongoing](/react-native/docs/android/behaviour#ongoing) documentation for more information.
+   * View the [Ongoing](/react-native/android/behaviour#ongoing) documentation for more information.
    */
   ongoing?: boolean;
 
@@ -266,7 +266,7 @@ export interface NotificationAndroid {
    * `pressAction` property allows you to set what happens when a user presses
    * the notification.
    *
-   * View the [Interaction](/react-native/docs/android/interaction) documentation to learn
+   * View the [Interaction](/react-native/android/interaction) documentation to learn
    * more.
    */
   pressAction?: NotificationPressAction;
@@ -275,7 +275,7 @@ export interface NotificationAndroid {
    * The `fullScreenAction` property allows you to show a custom UI
    * in full screen when the notification is displayed.
    *
-   * View the [FullScreenAction](/react-native/docs/android/behaviour#full-screen) documentation to learn
+   * View the [FullScreenAction](/react-native/android/behaviour#full-screen) documentation to learn
    * more.
    */
   fullScreenAction?: NotificationFullScreenAction;
@@ -298,7 +298,7 @@ export interface NotificationAndroid {
    *
    * Defaults to `AndroidImportance.DEFAULT`.
    *
-   * View the [Appearance](/react-native/docs/android/appearance#importance) documentation to learn
+   * View the [Appearance](/react-native/android/appearance#importance) documentation to learn
    * more.
    *
    * @platform android API Level < 26
@@ -309,7 +309,7 @@ export interface NotificationAndroid {
    * A notification can show current progress of a task. The progress state can either be fixed or
    * indeterminate (unknown).
    *
-   * View the [Progress Indicators](/react-native/docs/android/progress-indicators) documentation
+   * View the [Progress Indicators](/react-native/android/progress-indicators) documentation
    * to learn more.
    */
   progress?: AndroidProgress;
@@ -322,14 +322,14 @@ export interface NotificationAndroid {
    *
    * If no `timestamp` is set, this field has no effect.
    *
-   * View the [Timestamps](/react-native/docs/android/timers#timestamps) documentation to learn more.
+   * View the [Timestamps](/react-native/android/timers#timestamps) documentation to learn more.
    */
   showTimestamp?: boolean;
 
   /**
    * The small icon to show in the heads-up notification.
    *
-   * View the [Icons](/react-native/docs/android/appearance#small-icons) documentation to learn
+   * View the [Icons](/react-native/android/appearance#small-icons) documentation to learn
    * more.
    */
   smallIcon?: string;
@@ -347,7 +347,7 @@ export interface NotificationAndroid {
    *
    * If a `groupId` has been set, the sort key can also be used to order members of a notification group.
    *
-   * View the [Android Grouping & Sorting](/react-native/docs/android/grouping-and-sorting#sorting)
+   * View the [Android Grouping & Sorting](/react-native/android/grouping-and-sorting#sorting)
    * documentation to learn more.
    */
   sortKey?: string;
@@ -357,7 +357,7 @@ export interface NotificationAndroid {
    *
    * Android supports different styles, however only one can be used with a notification.
    *
-   * View the [Styles](/react-native/docs/android/styles) documentation to learn more
+   * View the [Styles](/react-native/android/styles) documentation to learn more
    * view usage examples.
    **/
   style?: AndroidBigPictureStyle | AndroidBigTextStyle | AndroidInboxStyle | AndroidMessagingStyle;
@@ -385,14 +385,14 @@ export interface NotificationAndroid {
    *
    * Defaults to `false`.
    *
-   * View the [Timers](/react-native/docs/android/timers#timers) documentation to learn more.
+   * View the [Timers](/react-native/android/timers#timers) documentation to learn more.
    */
   showChronometer?: boolean;
 
   /**
    * Sets the vibration pattern the notification uses when displayed. Must be an even amount of numbers.
    *
-   * View the [Vibration](/react-native/docs/android/behaviour#vibration) documentation to learn more.
+   * View the [Vibration](/react-native/android/behaviour#vibration) documentation to learn more.
    */
   vibrationPattern?: number[];
 
@@ -402,7 +402,7 @@ export interface NotificationAndroid {
    *
    * Defaults to `AndroidVisibility.PRIVATE`.
    *
-   * View the [Visibility](/react-native/docs/android/appearance#visibility) documentation to learn
+   * View the [Visibility](/react-native/android/appearance#visibility) documentation to learn
    * more.
    */
   visibility?: AndroidVisibility;
@@ -423,7 +423,7 @@ export interface NotificationAndroid {
    * - Use with `showTimestamp` to show the timestamp to the users.
    * - Use with `showChronometer` to create a on-going timer.
    *
-   * View the [Timers](/react-native/docs/android/timers) documentation to learn more.
+   * View the [Timers](/react-native/android/timers) documentation to learn more.
    */
   timestamp?: number;
 
@@ -435,7 +435,7 @@ export interface NotificationAndroid {
    * This setting has no behaviour on Android after API level version 26, instead you can set the
    * sound on the notification channels.
    *
-   * View the [Sound](/react-native/docs/android/behaviour#sound) documentation for more information.
+   * View the [Sound](/react-native/android/behaviour#sound) documentation for more information.
    *
    * @platform android API Level < 26
    */
@@ -448,7 +448,7 @@ export interface NotificationAndroid {
  * This interface is returned from [`requestPermission`](/react-native/reference/requestpermission)
  * and [`getNotificationSettings`](/react-native/reference/getnotificationsettings).
  *
- * View the [Permissions](/react-native/docs/android/permissions) documentation to learn more.
+ * View the [Permissions](/react-native/android/permissions) documentation to learn more.
  *
  * @platform android
  */
@@ -477,7 +477,7 @@ export interface AndroidNotificationSettings {
    *
    * For Android < 12 / API < 31, this will default to true
    *
-   * View the [Trigger](/react-native/docs/android/triggers#android-12-limitations) documentation for more information.
+   * View the [Trigger](/react-native/android/triggers#android-12-limitations) documentation for more information.
    */
   alarm: AndroidNotificationSetting;
 }
@@ -489,7 +489,7 @@ export interface AndroidNotificationSettings {
  * within your application. When an action completes (e.g. pressing an action, or filling out an input
  * box) an event is sent.
  *
- * View the [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation to learn more.
+ * View the [Quick Actions](/react-native/android/interaction#quick-actions) documentation to learn more.
  *
  * @platform android
  */
@@ -499,7 +499,7 @@ export interface AndroidAction {
    *
    * Note; unlike the `pressAction` in the notification body, an action does not need to open the application
    * and can perform background tasks. See the [AndroidPressAction](/react-native/reference/androidpressaction) reference
-   * or [Quick Actions](/react-native/docs/android/interaction#quick-actions) documentation to learn more.
+   * or [Quick Actions](/react-native/android/interaction#quick-actions) documentation to learn more.
    */
   pressAction: NotificationPressAction;
 
@@ -521,7 +521,7 @@ export interface AndroidAction {
    * If `true`, the user will be able to provide free text input when the action is pressed. This
    * property can be further configured for advanced inputs.
    *
-   * View the [Action Input](/react-native/docs/android/interaction#action-input) documentation to
+   * View the [Action Input](/react-native/android/interaction#action-input) documentation to
    * learn more.
    */
   input?: true | AndroidInput;
@@ -530,7 +530,7 @@ export interface AndroidAction {
 /**
  * The interface used to enable advanced user input on a notification.
  *
- * View the [Action Input](/react-native/docs/android/interaction#action-input) documentation to learn more.
+ * View the [Action Input](/react-native/android/interaction#action-input) documentation to learn more.
  *
  * @platform android
  */
@@ -584,7 +584,7 @@ export interface AndroidInput {
  *
  * <Vimeo id="android-style-bigpicture" caption="Android Big Picture Style" />
  *
- * View the [Big Picture](/react-native/docs/android/styles#big-picture) documentation to learn more.
+ * View the [Big Picture](/react-native/android/styles#big-picture) documentation to learn more.
  *
  * @platform android
  */
@@ -627,7 +627,7 @@ export interface AndroidBigPictureStyle {
  *
  * <Vimeo id="android-style-bigtext" caption="Android Big Text Style" />
  *
- * View the [Big Text](/react-native/docs/android/styles#big-text) documentation to learn more.
+ * View the [Big Text](/react-native/android/styles#big-text) documentation to learn more.
  *
  * @platform android
  */
@@ -658,7 +658,7 @@ export interface AndroidBigTextStyle {
  *
  * <Vimeo id="android-style-inbox" caption="Android Inbox Style" />
  *
- * View the [Inbox](/react-native/docs/android/styles#inbox) documentation to learn more.
+ * View the [Inbox](/react-native/android/styles#inbox) documentation to learn more.
  *
  * @platform android
  */
@@ -692,7 +692,7 @@ export interface AndroidInboxStyle {
  *
  * <Vimeo id="android-style-messaging" caption="Android Messaging Style" />
  *
- * View the [Messaging](/react-native/docs/android/styles#messaging) documentation to learn more.
+ * View the [Messaging](/react-native/android/styles#messaging) documentation to learn more.
  *
  * @platform android
  */
@@ -729,7 +729,7 @@ export interface AndroidMessagingStyle {
  * <Vimeo id="android-style-messaging" caption="Android Messaging Style" />
  *
  * View the [`AndroidMessagingStyle`](/react-native/reference/androidmessagingstyle) reference
- * and [Messaging](/react-native/docs/android/styles#messaging) documentation to learn more.
+ * and [Messaging](/react-native/android/styles#messaging) documentation to learn more.
  *
  * @platform android
  */
@@ -817,7 +817,7 @@ export interface AndroidPerson {
  *
  * <Vimeo id="android-progress-summary" caption="Android Progress (w/ Big Picture Style)" />
  *
- * View the [Progress Indicators](/react-native/docs/android/progress-indicators) documentation to learn more.
+ * View the [Progress Indicators](/react-native/android/progress-indicators) documentation to learn more.
  *
  * @platform android
  */
@@ -851,7 +851,7 @@ export interface AndroidProgress {
  * Channels override any individual notification preferences (e.g. lights/vibration) and the user
  * has final control over the setting. Once created, only channel metadata can be updated (e.g. name).
  *
- * View the [Channels & Groups](/react-native/docs/android/channels) documentation to learn more.
+ * View the [Channels & Groups](/react-native/android/channels) documentation to learn more.
  *
  * @platform android
  */
@@ -872,7 +872,7 @@ export interface AndroidChannel {
   /**
    * Sets whether badges are enabled for the channel.
    *
-   * View the [Badges](/react-native/docs/android/appearance#badges) documentation to learn more.
+   * View the [Badges](/react-native/android/appearance#badges) documentation to learn more.
    *
    * Defaults to `true`.
    *
@@ -997,7 +997,7 @@ export interface NativeAndroidChannel extends AndroidChannel {
    *
    * On API levels < 28, returns `false`.
    *
-   * View the [Listening to channel events](/react-native/docs/android/channels#listening-to-channel-events)
+   * View the [Listening to channel events](/react-native/android/channels#listening-to-channel-events)
    * documentation to learn more about subscribing to when a channel is blocked by the user.
    *
    * @platform android API Level >= 28
@@ -1011,7 +1011,7 @@ export interface NativeAndroidChannel extends AndroidChannel {
  * Channel groups have no impact on the notification, they are used to help group channels in the applications
  * settings UI.
  *
- * View the [Channels & Groups](/react-native/docs/android/channels) documentation to learn more.
+ * View the [Channels & Groups](/react-native/android/channels) documentation to learn more.
  *
  * @platform android API Level >= 26
  */
@@ -1053,7 +1053,7 @@ export interface NativeAndroidChannelGroup extends AndroidChannelGroup {
    *
    * On API levels < 28, returns `false`.
    *
-   * View the [Listening to channel events](/react-native/docs/android/channels#listening-to-channel-events)
+   * View the [Listening to channel events](/react-native/android/channels#listening-to-channel-events)
    * documentation to learn more about subscribing to when a channel is blocked by the user.
    *
    * @platform android API Level >= 28
@@ -1069,7 +1069,7 @@ export interface NativeAndroidChannelGroup extends AndroidChannelGroup {
 /**
  * Enum used to define how a notification badge is displayed in badge mode.
  *
- * View the [Badges](/react-native/docs/android/appearance#badges) documentation for more information.
+ * View the [Badges](/react-native/android/appearance#badges) documentation for more information.
  *
  * @platform android
  */
@@ -1127,7 +1127,7 @@ export enum AndroidCategory {
 /**
  * A set or predefined colors which can be used with Android Notifications.
  *
- * View the [Color](/react-native/docs/android/appearance#color) documentation to learn more.
+ * View the [Color](/react-native/android/appearance#color) documentation to learn more.
  *
  * @platform android
  */
@@ -1209,7 +1209,7 @@ export enum AndroidFlags {
 /**
  * Enum used to describe how a notification alerts the user when it apart of a group.
  *
- * View the [Grouping & Sorting](/react-native/docs/android/grouping-and-sorting#group-behaviour) documentation to
+ * View the [Grouping & Sorting](/react-native/android/grouping-and-sorting#group-behaviour) documentation to
  * learn more.
  *
  * @platform android
@@ -1234,7 +1234,7 @@ export enum AndroidGroupAlertBehavior {
 /**
  * Available Android Notification Styles.
  *
- * View the [Styles](/react-native/docs/android/styles) documentation to learn more with example usage.
+ * View the [Styles](/react-native/android/styles) documentation to learn more with example usage.
  *
  * @platform android
  */
@@ -1250,7 +1250,7 @@ export enum AndroidStyle {
  *
  * Use with the `visibility` property on the notification.
  *
- * View the [Visibility](/react-native/docs/android/appearance#visibility) documentation to learn more.
+ * View the [Visibility](/react-native/android/appearance#visibility) documentation to learn more.
  *
  * Default value is `AndroidVisibility.PRIVATE`.
  *
@@ -1284,7 +1284,7 @@ export enum AndroidVisibility {
  * The importance is used to both change the visual prompt of a received notification
  * and also how it visually appears on the device.
  *
- * View the [Android Appearance](/react-native/docs/android/appearance#importance) documentation to learn more.
+ * View the [Android Appearance](/react-native/android/appearance#importance) documentation to learn more.
  *
  * @platform android
  */

--- a/packages/react-native/src/types/NotificationIOS.ts
+++ b/packages/react-native/src/types/NotificationIOS.ts
@@ -6,7 +6,7 @@ import { AuthorizationStatus } from './Notification';
 /**
  * The interface for iOS specific options which are applied to a notification.
  *
- * To learn more about iOS notifications, view the [iOS](/react-native/docs/iOS/introduction)
+ * To learn more about iOS notifications, view the [iOS](/react-native/iOS/introduction)
  * documentation for full examples and usage.
  *
  * @platform ios
@@ -17,7 +17,7 @@ export interface NotificationIOS {
    *
    * Attachments allow audio, image, or video content to be displayed with the notification, enriching the user's experience.
    *
-   * View the [Attachments](/react-native/docs/ios/appearances#attachments) documentation for more information
+   * View the [Attachments](/react-native/ios/appearances#attachments) documentation for more information
    * and usage examples.
    */
   attachments?: IOSNotificationAttachment[];
@@ -149,7 +149,7 @@ export interface IOSCommunicationInfoPerson {
  *
  * By default, Notifee will show iOS notifications in heads-up mode if your app is currently in the foreground.
  *
- * View the [Foreground Notifications](/react-native/docs/ios/appearance#foreground-notifications) to learn
+ * View the [Foreground Notifications](/react-native/ios/appearance#foreground-notifications) to learn
  * more.
  *
  * @platform ios
@@ -200,7 +200,7 @@ export interface IOSForegroundPresentationOptions {
  * An interface representing all the available permissions that can be requested by your app via
  * the [`requestPermission`](/react-native/reference/requestpermission) API.
  *
- * View the [Permissions](/react-native/docs/ios/permissions) to learn
+ * View the [Permissions](/react-native/ios/permissions) to learn
  * more.
  *
  * @platform ios
@@ -216,7 +216,7 @@ export interface IOSNotificationPermissions {
   /**
    * Request permission to display critical notifications.
    *
-   * View the [Critical Notifications](/react-native/docs/ios/behaviour#critical-notifications) documentation for more information
+   * View the [Critical Notifications](/react-native/ios/behaviour#critical-notifications) documentation for more information
    * and usage examples.
    *
    * Defaults to false.
@@ -339,7 +339,7 @@ export enum IOSNotificationSetting {
  * This interface is returned from [`requestPermission`](/react-native/reference/requestpermission)
  * and [`getNotificationSettings`](/react-native/reference/getnotificationsettings).
  *
- * View the [Observing Settings](/react-native/docs/ios/permissions#observing-settings) documentation to learn more.
+ * View the [Observing Settings](/react-native/ios/permissions#observing-settings) documentation to learn more.
  *
  * @platform ios
  */
@@ -463,7 +463,7 @@ export enum IOSIntentIdentifier {
  *
  * At minimum, a category must be created with a unique identifier, all other properties are optional.
  *
- * View the [Categories](/react-native/docs/ios/categories) documentation to learn more.
+ * View the [Categories](/react-native/ios/categories) documentation to learn more.
  *
  * @platform ios
  */
@@ -476,7 +476,7 @@ export interface IOSNotificationCategory {
   /**
    * Specify a custom format for the summary text, which is visible when notifications are grouped together.
    *
-   * View the [Summary Text](/react-native/docs/ios/categories#category-summary-text) documentation to learn more.
+   * View the [Summary Text](/react-native/ios/categories#category-summary-text) documentation to learn more.
    */
   summaryFormat?: string;
 
@@ -539,7 +539,7 @@ export interface IOSNotificationCategory {
  * within your application. When an action completes (e.g. pressing an action, or filling out an input
  * box) an event is sent.
  *
- * View the [Quick Actions](/react-native/docs/ios/interaction#quick-actions) documentation to learn more.
+ * View the [Quick Actions](/react-native/ios/interaction#quick-actions) documentation to learn more.
  *
  * @platform ios
  */
@@ -559,7 +559,7 @@ export interface IOSNotificationCategoryAction {
    * The placeholder and button text can be customized by providing an object
    * of type [`IOSInput`](/react-native/reference/iosinput).
    *
-   * View the [Action Input](/react-native/docs/ios/interaction#action-input) documentation to
+   * View the [Action Input](/react-native/ios/interaction#action-input) documentation to
    * learn more.
    */
   input?: true | IOSInput;
@@ -583,7 +583,7 @@ export interface IOSNotificationCategoryAction {
 /**
  * The interface used to enable advanced user input on a notification.
  *
- * View the [Action input](/react-native/docs/ios/interaction#action-input) documentation to learn more.
+ * View the [Action input](/react-native/ios/interaction#action-input) documentation to learn more.
  *
  * @platform ios
  */
@@ -602,7 +602,7 @@ export interface IOSInput {
 /**
  * An interface for describing an iOS Notification Attachment.
  *
- * View the [Attachments](/react-native/docs/ios/appearance#attachments) documentation to learn more.
+ * View the [Attachments](/react-native/ios/appearance#attachments) documentation to learn more.
  *
  * @platform ios
  */

--- a/packages/react-native/src/types/PowerManagerInfo.ts
+++ b/packages/react-native/src/types/PowerManagerInfo.ts
@@ -5,7 +5,7 @@
 /**
  * The interface that represents the information returned from `getPowerManagerInfo()`.
  *
- * View the [Background Restrictions](/react-native/docs/android/background-restrictions) documentation to learn more.
+ * View the [Background Restrictions](/react-native/android/background-restrictions) documentation to learn more.
  *
  * @platform android
  */

--- a/packages/react-native/src/types/Trigger.ts
+++ b/packages/react-native/src/types/Trigger.ts
@@ -1,7 +1,7 @@
 /**
  * Interface for building a trigger with a timestamp.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ * View the [Triggers](/react-native/triggers) documentation to learn more.
  */
 export interface TimestampTrigger {
   /**
@@ -37,7 +37,7 @@ export interface TimestampTrigger {
 /**
  * An interface representing the different alarm types which can be used with `TimestampTrigger.alarmManager.type`.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ * View the [Triggers](/react-native/triggers) documentation to learn more.
  */
 export enum AlarmType {
   SET,
@@ -50,7 +50,7 @@ export enum AlarmType {
 /**
  * Interface to specify additional options for the AlarmManager which can be used with `TimestampTrigger.alarmManager`.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ * View the [Triggers](/react-native/triggers) documentation to learn more.
  *
  * @platform android
  */
@@ -72,7 +72,7 @@ export interface TimestampTriggerAlarmManager {
 /**
  * An interface representing the different frequencies which can be used with `TimestampTrigger.repeatFrequency`.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ * View the [Triggers](/react-native/triggers) documentation to learn more.
  */
 export enum RepeatFrequency {
   NONE = -1,
@@ -84,7 +84,7 @@ export enum RepeatFrequency {
 /**
  * Interface for building a trigger that repeats at a specified interval.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ * View the [Triggers](/react-native/triggers) documentation to learn more.
  */
 export interface IntervalTrigger {
   /**
@@ -114,7 +114,7 @@ export interface IntervalTrigger {
 /**
  * An interface representing the different units of time which can be used with `IntervalTrigger.timeUnit`.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more.
+ * View the [Triggers](/react-native/triggers) documentation to learn more.
  */
 export enum TimeUnit {
   SECONDS = 'SECONDS',
@@ -126,7 +126,7 @@ export enum TimeUnit {
 /**
  * Available Trigger Types.
  *
- * View the [Triggers](/react-native/docs/triggers) documentation to learn more with example usage.
+ * View the [Triggers](/react-native/triggers) documentation to learn more with example usage.
  */
 export enum TriggerType {
   TIMESTAMP = 0,

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -1,0 +1,70 @@
+/** @type {Partial<import("typedoc").TypeDocOptions>} */
+import { OptionDefaults } from 'typedoc';
+
+const config = {
+  entryPoints: ['./packages/react-native/src/index.ts'],
+  hostedBaseUrl: 'https://docs.page/invertase/notifee/react-native/reference',
+
+  // If we generate markdown directly then replace the internal links with
+  // a version that strips the `.mdx` suffix, we can match what docs.page
+  // expects directly, no need for separate hosting.
+  plugin: ['typedoc-plugin-markdown', 'typedoc-plugin-remark'],
+
+  // Generate the typedoc in a subtree of our main / manually-created docs
+  out: './docs/react-native/reference',
+
+  // Make the main file index.mdx (instead of 'README.mdx')
+  entryFileName: 'index',
+
+  // we don't need to duplicate the Notifee README in the reference docs
+  readme: 'none',
+
+  // We don't want specific commit SHAs in our links because it makes the whole
+  // reference site change with every commit. Just link to `main`
+  gitRevision: 'main',
+
+  // docs.page works with `.mdx` file extensions, not the default `.md` extensions
+  // ...but we do need to make internal links that strip the suffix
+  fileExtension: '.mdx',
+
+  // docs.page has a different base URL then the output expects and tree hierarchies
+  // don't work the way typedoc expects. If typedoc generates a flat structure the
+  // problem of tree hierarchies is completely avoided
+  flattenOutputFiles: true,
+
+  // it is possible to do a single page or control output if you like
+  // mergeReadme: true,
+  // enumMembersFormat: 'table',
+  // parametersFormat: 'table',
+  // propertiesFormat: 'table',
+  // typeDeclarationFormat: 'table',
+  // indexFormat: 'table',
+  // outputFileStrategy: 'modules',
+
+  // We use a `@platform` tag which is non-default, educate typedoc about it
+  blockTags: [...OptionDefaults.blockTags, '@platform'],
+
+  remarkPlugins: [
+    [
+      'remark-link-rewrite',
+      {
+        replacer: url => {
+          if (url.startsWith('/react-native/')) return url;
+
+          let modifiedUrl = url;
+
+          // Remove `.mdx` from all other URLs so docs.page links work
+          // (docs.page uses .mdx files but expects links to be without the `.mdx`)
+          modifiedUrl = url.replace('.mdx', '');
+
+          // For relative links we need to add the path components docs.page expects
+          if (!url.includes('/')) modifiedUrl = 'react-native/reference/' + modifiedUrl;
+
+          return modifiedUrl;
+        },
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1280,6 +1280,15 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@gerrit0/mini-shiki@^1.24.0":
+  version "1.24.4"
+  resolved "https://registry.yarnpkg.com/@gerrit0/mini-shiki/-/mini-shiki-1.24.4.tgz#e5328ca0dccc094460c03701d62158137a5a2eda"
+  integrity sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==
+  dependencies:
+    "@shikijs/engine-oniguruma" "^1.24.2"
+    "@shikijs/types" "^1.24.2"
+    "@shikijs/vscode-textmate" "^9.3.1"
+
 "@google-cloud/firestore@^4.15.1":
   version "4.15.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/firestore/-/firestore-4.15.1.tgz#ed764fc76823ce120e68fe8c27ef1edd0650cd93"
@@ -3330,6 +3339,27 @@
     lodash-es "^4.17.21"
     read-package-up "^11.0.0"
 
+"@shikijs/engine-oniguruma@^1.24.2":
+  version "1.24.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.3.tgz#e549cb6f2050113ac65994b4e98f4704c3e427e8"
+  integrity sha512-iNnx950gs/5Nk+zrp1LuF+S+L7SKEhn8k9eXgFYPGhVshKppsYwRmW8tpmAMvILIMSDfrgqZ0w+3xWVQB//1Xw==
+  dependencies:
+    "@shikijs/types" "1.24.3"
+    "@shikijs/vscode-textmate" "^9.3.1"
+
+"@shikijs/types@1.24.3", "@shikijs/types@^1.24.2":
+  version "1.24.3"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-1.24.3.tgz#6700007019cc5c2fa5db32ab1595f01b1e79d969"
+  integrity sha512-FPMrJ69MNxhRtldRk69CghvaGlbbN3pKRuvko0zvbfa2dXp4pAngByToqS5OY5jvN8D7LKR4RJE8UvzlCOuViw==
+  dependencies:
+    "@shikijs/vscode-textmate" "^9.3.1"
+    "@types/hast" "^3.0.4"
+
+"@shikijs/vscode-textmate@^9.3.1":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz#afda31f8f42cab70a26f3603f52eae3f1c35d2f7"
+  integrity sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==
+
 "@sideway/address@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.5.tgz#4bc149a0076623ced99ca8208ba780d65a99b9d5"
@@ -3445,6 +3475,13 @@
     "@tufjs/canonical-json" "2.0.0"
     minimatch "^9.0.5"
 
+"@types/acorn@^4.0.0":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
+  integrity sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==
+  dependencies:
+    "@types/estree" "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -3505,6 +3542,25 @@
   dependencies:
     "@types/node" "*"
 
+"@types/debug@^4.0.0":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
+  integrity sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==
+  dependencies:
+    "@types/ms" "*"
+
+"@types/estree-jsx@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-1.0.5.tgz#858a88ea20f34fe65111f005a689fa1ebf70dc18"
+  integrity sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==
+  dependencies:
+    "@types/estree" "*"
+
+"@types/estree@*", "@types/estree@^1.0.0":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
+  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.19.6"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz#e01324c2a024ff367d92c66f48553ced0ab50267"
@@ -3531,6 +3587,13 @@
   integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
   dependencies:
     "@types/node" "*"
+
+"@types/hast@^3.0.0", "@types/hast@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-3.0.4.tgz#1d6b39993b82cea6ad783945b0508c25903e15aa"
+  integrity sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
+  dependencies:
+    "@types/unist" "*"
 
 "@types/http-errors@*":
   version "2.0.4"
@@ -3581,6 +3644,13 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
+"@types/mdast@^4.0.0":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-4.0.4.tgz#7ccf72edd2f1aa7dd3437e180c64373585804dd6"
+  integrity sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/mime@^1":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
@@ -3595,6 +3665,11 @@
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
   integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
+
+"@types/ms@*":
+  version "0.7.34"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
+  integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^17.0.21":
   version "17.0.45"
@@ -3673,6 +3748,16 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/unist@*", "@types/unist@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
+  integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
+
+"@types/unist@^2.0.0":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
+  integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -3853,7 +3938,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@^5.0.0, acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -3868,7 +3953,7 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4:
+acorn@^8.0.0, acorn@^8.2.4:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
@@ -4440,6 +4525,11 @@ babel-preset-jest@^27.5.1:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
 
+bail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
+  integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -4788,6 +4878,11 @@ cavy@^4.0.2:
     hoist-non-react-statics "^3.3.0"
     prop-types "^15.5.10"
 
+ccount@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
+  integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
 chai@^4.3.6:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
@@ -4827,6 +4922,26 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+character-entities-html4@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-2.1.0.tgz#1f1adb940c971a4b22ba39ddca6b618dc6e56b2b"
+  integrity sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+
+character-entities-legacy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz#76bc83a90738901d7bc223a9e93759fdd560125b"
+  integrity sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+
+character-entities@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
+  integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
+character-reference-invalid@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz#85c66b041e43b47210faf401278abf808ac45cb9"
+  integrity sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -5557,6 +5672,13 @@ decimal.js@^10.2.1:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
+decode-named-character-reference@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz#daabac9690874c394c81e4162a0304b35d824f0e"
+  integrity sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==
+  dependencies:
+    character-entities "^2.0.0"
+
 decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
@@ -5666,6 +5788,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
@@ -5685,6 +5812,13 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+devlop@^1.0.0, devlop@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/devlop/-/devlop-1.1.0.tgz#4db7c2ca4dc6e0e834c30be70c94bbc976dc7018"
+  integrity sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+  dependencies:
+    dequal "^2.0.0"
 
 dezalgo@^1.0.0:
   version "1.0.4"
@@ -5873,6 +6007,11 @@ ent@^2.2.0:
   dependencies:
     punycode "^1.4.1"
 
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
 env-ci@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/env-ci/-/env-ci-11.1.0.tgz#b26eeb692f76c1f69ddc1fb2d4a3d371088a54f9"
@@ -6055,7 +6194,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@5.0.0:
+escape-string-regexp@5.0.0, escape-string-regexp@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
@@ -6291,6 +6430,19 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-util-is-identifier-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz#0b5ef4c4ff13508b34dcd01ecfa945f61fce5dbd"
+  integrity sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==
+
+estree-util-visit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/estree-util-visit/-/estree-util-visit-2.0.0.tgz#13a9a9f40ff50ed0c022f831ddf4b58d05446feb"
+  integrity sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/unist" "^3.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -6420,7 +6572,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.2, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -6510,6 +6662,13 @@ fastq@^1.6.0:
   integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
+
+fault@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-2.0.1.tgz#d47ca9f37ca26e4bd38374a7c500b5a384755b6c"
+  integrity sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==
+  dependencies:
+    format "^0.2.0"
 
 faye-websocket@0.11.4:
   version "0.11.4"
@@ -6762,6 +6921,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -6809,7 +6973,7 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
+fs-extra@^9.0.0, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -7268,7 +7432,7 @@ gtoken@^5.0.4:
     google-p12-pem "^3.1.3"
     jws "^4.0.0"
 
-handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@^4.7.7:
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
   integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
@@ -7423,7 +7587,7 @@ hermes-profile-transformer@^0.0.6:
   dependencies:
     source-map "^0.7.3"
 
-highlight.js@^10.2.0, highlight.js@^10.7.1:
+highlight.js@^10.7.1:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
@@ -7804,6 +7968,19 @@ is-accessor-descriptor@^1.0.1:
   dependencies:
     hasown "^2.0.0"
 
+is-alphabetical@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-2.0.1.tgz#01072053ea7c1036df3c7d19a6daaec7f19e789b"
+  integrity sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==
+
+is-alphanumerical@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz#7c03fbe96e3e931113e57f964b0a368cc2dfd875"
+  integrity sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==
+  dependencies:
+    is-alphabetical "^2.0.0"
+    is-decimal "^2.0.0"
+
 is-array-buffer@^3.0.4:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
@@ -7895,6 +8072,11 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
 
+is-decimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
+  integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
+
 is-descriptor@^0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.7.tgz#2727eb61fd789dcd5bdf0ed4569f551d2fe3be33"
@@ -7981,6 +8163,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
+  integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
@@ -8036,7 +8223,7 @@ is-plain-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
-is-plain-obj@^4.1.0:
+is-plain-obj@^4.0.0, is-plain-obj@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
@@ -9306,6 +9493,13 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
+
 load-json-file@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
@@ -9471,7 +9665,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9509,6 +9703,11 @@ long@^5.0.0:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
+longest-streak@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
+  integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -9672,6 +9871,23 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.1.0.tgz#3c3c5992883c633db4714ccb4d7b5935d98b7d45"
+  integrity sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.1.0"
+
+markdown-table@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-3.0.4.tgz#fe44d6d410ff9d6f2ea1797a3f60aa4d2b631c2a"
+  integrity sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==
+
 marked-terminal@^7.0.0:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-7.2.1.tgz#9c1ae073a245a03c6a13e3eeac6f586f29856068"
@@ -9684,11 +9900,6 @@ marked-terminal@^7.0.0:
     cli-table3 "^0.6.5"
     node-emoji "^2.1.3"
     supports-hyperlinks "^3.1.0"
-
-marked@^1.1.1:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
 
 marked@^12.0.0:
   version "12.0.2"
@@ -9704,6 +9915,199 @@ math-intrinsics@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.0.0.tgz#4e04bf87c85aa51e90d078dac2252b4eb5260817"
   integrity sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==
+
+mdast-util-find-and-replace@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz#a6fc7b62f0994e973490e45262e4bc07607b04e0"
+  integrity sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    escape-string-regexp "^5.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
+mdast-util-from-markdown@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz#4850390ca7cf17413a9b9a0fbefcd1bc0eb4160a"
+  integrity sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark "^4.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+mdast-util-frontmatter@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz#f5f929eb1eb36c8a7737475c7eb438261f964ee8"
+  integrity sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    escape-string-regexp "^5.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    micromark-extension-frontmatter "^2.0.0"
+
+mdast-util-gfm-autolink-literal@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz#abd557630337bd30a6d5a4bd8252e1c2dc0875d5"
+  integrity sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    ccount "^2.0.0"
+    devlop "^1.0.0"
+    mdast-util-find-and-replace "^3.0.0"
+    micromark-util-character "^2.0.0"
+
+mdast-util-gfm-footnote@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz#25a1753c7d16db8bfd53cd84fe50562bd1e6d6a9"
+  integrity sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.1.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+
+mdast-util-gfm-strikethrough@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz#d44ef9e8ed283ac8c1165ab0d0dfd058c2764c16"
+  integrity sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz#7a435fb6223a72b0862b33afbd712b6dae878d38"
+  integrity sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    markdown-table "^3.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm-task-list-item@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz#e68095d2f8a4303ef24094ab642e1047b991a936"
+  integrity sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-gfm@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz#3f2aecc879785c3cb6a81ff3a243dc11eca61095"
+  integrity sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==
+  dependencies:
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-gfm-autolink-literal "^2.0.0"
+    mdast-util-gfm-footnote "^2.0.0"
+    mdast-util-gfm-strikethrough "^2.0.0"
+    mdast-util-gfm-table "^2.0.0"
+    mdast-util-gfm-task-list-item "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdx-expression@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz#43f0abac9adc756e2086f63822a38c8d3c3a5096"
+  integrity sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdx-jsx@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.3.tgz#76b957b3da18ebcfd0de3a9b4451dcd6fdec2320"
+  integrity sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    devlop "^1.1.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    parse-entities "^4.0.0"
+    stringify-entities "^4.0.0"
+    unist-util-stringify-position "^4.0.0"
+    vfile-message "^4.0.0"
+
+mdast-util-mdx@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz#792f9cf0361b46bee1fdf1ef36beac424a099c41"
+  integrity sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==
+  dependencies:
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-mdx-expression "^2.0.0"
+    mdast-util-mdx-jsx "^3.0.0"
+    mdast-util-mdxjs-esm "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-mdxjs-esm@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz#019cfbe757ad62dd557db35a695e7314bcc9fa97"
+  integrity sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==
+  dependencies:
+    "@types/estree-jsx" "^1.0.0"
+    "@types/hast" "^3.0.0"
+    "@types/mdast" "^4.0.0"
+    devlop "^1.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    mdast-util-to-markdown "^2.0.0"
+
+mdast-util-phrasing@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
+  integrity sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    unist-util-is "^6.0.0"
+
+mdast-util-to-markdown@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz#f910ffe60897f04bb4b7e7ee434486f76288361b"
+  integrity sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    "@types/unist" "^3.0.0"
+    longest-streak "^3.0.0"
+    mdast-util-phrasing "^4.0.0"
+    mdast-util-to-string "^4.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-decode-string "^2.0.0"
+    unist-util-visit "^5.0.0"
+    zwitch "^2.0.0"
+
+mdast-util-to-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz#7a5121475556a04e7eddeb67b264aae79d312814"
+  integrity sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 memoize-one@^5.0.0:
   version "5.2.1"
@@ -10244,6 +10648,385 @@ metro@0.70.4, metro@^0.70.4:
     ws "^7.5.1"
     yargs "^15.3.1"
 
+micromark-core-commonmark@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz#6a45bbb139e126b3f8b361a10711ccc7c6e15e93"
+  integrity sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-destination "^2.0.0"
+    micromark-factory-label "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-factory-title "^2.0.0"
+    micromark-factory-whitespace "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-html-tag-name "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-frontmatter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz#651c52ffa5d7a8eeed687c513cd869885882d67a"
+  integrity sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==
+  dependencies:
+    fault "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-autolink-literal@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz#6286aee9686c4462c1e3552a9d505feddceeb935"
+  integrity sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-footnote@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz#4dab56d4e398b9853f6fe4efac4fc9361f3e0750"
+  integrity sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-strikethrough@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz#86106df8b3a692b5f6a92280d3879be6be46d923"
+  integrity sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-classify-character "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-table@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz#5cadedfbb29fca7abf752447967003dc3b6583c9"
+  integrity sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-tagfilter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz#f26d8a7807b5985fba13cf61465b58ca5ff7dc57"
+  integrity sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm-task-list-item@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz#bcc34d805639829990ec175c3eea12bb5b781f2c"
+  integrity sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-gfm@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz#3e13376ab95dd7a5cfd0e29560dfe999657b3c5b"
+  integrity sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==
+  dependencies:
+    micromark-extension-gfm-autolink-literal "^2.0.0"
+    micromark-extension-gfm-footnote "^2.0.0"
+    micromark-extension-gfm-strikethrough "^2.0.0"
+    micromark-extension-gfm-table "^2.0.0"
+    micromark-extension-gfm-tagfilter "^2.0.0"
+    micromark-extension-gfm-task-list-item "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-mdx-expression@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.0.tgz#1407b9ce69916cf5e03a196ad9586889df25302a"
+  integrity sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-mdx-expression "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-extension-mdx-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.1.tgz#5abb83da5ddc8e473a374453e6ea56fbd66b59ad"
+  integrity sha512-vNuFb9czP8QCtAQcEJn0UJQJZA8Dk6DXKBqx+bg/w0WGuSxDxNr7hErW89tHUY31dUW4NqEOWwmEUNhjTFmHkg==
+  dependencies:
+    "@types/acorn" "^4.0.0"
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    estree-util-is-identifier-name "^3.0.0"
+    micromark-factory-mdx-expression "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    vfile-message "^4.0.0"
+
+micromark-extension-mdx-md@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz#1d252881ea35d74698423ab44917e1f5b197b92d"
+  integrity sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-extension-mdxjs-esm@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz#de21b2b045fd2059bd00d36746081de38390d54a"
+  integrity sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-position-from-estree "^2.0.0"
+    vfile-message "^4.0.0"
+
+micromark-extension-mdxjs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz#b5a2e0ed449288f3f6f6c544358159557549de18"
+  integrity sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==
+  dependencies:
+    acorn "^8.0.0"
+    acorn-jsx "^5.0.0"
+    micromark-extension-mdx-expression "^3.0.0"
+    micromark-extension-mdx-jsx "^3.0.0"
+    micromark-extension-mdx-md "^2.0.0"
+    micromark-extension-mdxjs-esm "^3.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-destination@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz#8fef8e0f7081f0474fbdd92deb50c990a0264639"
+  integrity sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-label@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz#5267efa97f1e5254efc7f20b459a38cb21058ba1"
+  integrity sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-mdx-expression@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.2.tgz#2afaa8ba6d5f63e0cead3e4dee643cad184ca260"
+  integrity sha512-5E5I2pFzJyg2CtemqAbcyCktpHXuJbABnsb32wX2U8IQKhhVFBqkcZR5LRm1WVoFqa4kTueZK4abep7wdo9nrw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    devlop "^1.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-events-to-acorn "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unist-util-position-from-estree "^2.0.0"
+    vfile-message "^4.0.0"
+
+micromark-factory-space@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz#36d0212e962b2b3121f8525fc7a3c7c029f334fc"
+  integrity sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-title@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz#237e4aa5d58a95863f01032d9ee9b090f1de6e94"
+  integrity sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-factory-whitespace@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz#06b26b2983c4d27bfcc657b33e25134d4868b0b1"
+  integrity sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==
+  dependencies:
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-character@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-2.1.1.tgz#2f987831a40d4c510ac261e89852c4e9703ccda6"
+  integrity sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-chunked@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz#47fbcd93471a3fccab86cff03847fc3552db1051"
+  integrity sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-classify-character@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz#d399faf9c45ca14c8b4be98b1ea481bced87b629"
+  integrity sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-combine-extensions@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz#2a0f490ab08bff5cc2fd5eec6dd0ca04f89b30a9"
+  integrity sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==
+  dependencies:
+    micromark-util-chunked "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-decode-numeric-character-reference@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz#fcf15b660979388e6f118cdb6bf7d79d73d26fe5"
+  integrity sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-decode-string@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz#6cb99582e5d271e84efca8e61a807994d7161eb2"
+  integrity sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==
+  dependencies:
+    decode-named-character-reference "^1.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-encode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz#0d51d1c095551cfaac368326963cf55f15f540b8"
+  integrity sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+
+micromark-util-events-to-acorn@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.2.tgz#4275834f5453c088bd29cd72dfbf80e3327cec07"
+  integrity sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==
+  dependencies:
+    "@types/acorn" "^4.0.0"
+    "@types/estree" "^1.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    estree-util-visit "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+    vfile-message "^4.0.0"
+
+micromark-util-html-tag-name@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz#e40403096481986b41c106627f98f72d4d10b825"
+  integrity sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==
+
+micromark-util-normalize-identifier@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz#c30d77b2e832acf6526f8bf1aa47bc9c9438c16d"
+  integrity sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==
+  dependencies:
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-resolve-all@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz#e1a2d62cdd237230a2ae11839027b19381e31e8b"
+  integrity sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==
+  dependencies:
+    micromark-util-types "^2.0.0"
+
+micromark-util-sanitize-uri@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz#ab89789b818a58752b73d6b55238621b7faa8fd7"
+  integrity sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+  dependencies:
+    micromark-util-character "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+
+micromark-util-subtokenize@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.3.tgz#70ffb99a454bd8c913c8b709c3dc97baefb65f96"
+  integrity sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==
+  dependencies:
+    devlop "^1.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
+micromark-util-symbol@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz#e5da494e8eb2b071a0d08fb34f6cefec6c0a19b8"
+  integrity sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+
+micromark-util-types@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/micromark-util-types/-/micromark-util-types-2.0.1.tgz#a3edfda3022c6c6b55bfb049ef5b75d70af50709"
+  integrity sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==
+
+micromark@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-4.0.1.tgz#294c2f12364759e5f9e925a767ae3dfde72223ff"
+  integrity sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==
+  dependencies:
+    "@types/debug" "^4.0.0"
+    debug "^4.0.0"
+    decode-named-character-reference "^1.0.0"
+    devlop "^1.0.0"
+    micromark-core-commonmark "^2.0.0"
+    micromark-factory-space "^2.0.0"
+    micromark-util-character "^2.0.0"
+    micromark-util-chunked "^2.0.0"
+    micromark-util-combine-extensions "^2.0.0"
+    micromark-util-decode-numeric-character-reference "^2.0.0"
+    micromark-util-encode "^2.0.0"
+    micromark-util-normalize-identifier "^2.0.0"
+    micromark-util-resolve-all "^2.0.0"
+    micromark-util-sanitize-uri "^2.0.0"
+    micromark-util-subtokenize "^2.0.0"
+    micromark-util-symbol "^2.0.0"
+    micromark-util-types "^2.0.0"
+
 micromatch@^3.1.10:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -10328,7 +11111,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -11559,6 +12342,19 @@ parse-conflict-json@^4.0.0:
     just-diff "^6.0.0"
     just-diff-apply "^5.2.0"
 
+parse-entities@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-4.0.2.tgz#61d46f5ed28e4ee62e9ddc43d6b010188443f159"
+  integrity sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    character-entities-legacy "^3.0.0"
+    character-reference-invalid "^2.0.0"
+    decode-named-character-reference "^1.0.0"
+    is-alphanumerical "^2.0.0"
+    is-decimal "^2.0.0"
+    is-hexadecimal "^2.0.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -11875,7 +12671,7 @@ proggy@^3.0.0:
   resolved "https://registry.yarnpkg.com/proggy/-/proggy-3.0.0.tgz#874e91fed27fe00a511758e83216a6b65148bd6c"
   integrity sha512-QE8RApCM3IaRRxVzxrjbgNMpQEX6Wu0p0KBeoSiSEw5/bsGwZHsshF4LCxH2jp/r6BU+bqA3LrMDEYNfJnpD8Q==
 
-progress@^2.0.0, progress@^2.0.3:
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -12042,6 +12838,11 @@ pumpify@^2.0.0:
     duplexify "^4.1.1"
     inherits "^2.0.3"
     pump "^3.0.0"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -12506,6 +13307,72 @@ regjsparser@^0.12.0:
   dependencies:
     jsesc "~3.0.2"
 
+remark-frontmatter@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz#b68d61552a421ec412c76f4f66c344627dc187a2"
+  integrity sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-frontmatter "^2.0.0"
+    micromark-extension-frontmatter "^2.0.0"
+    unified "^11.0.0"
+
+remark-gfm@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.0.tgz#aea777f0744701aa288b67d28c43565c7e8c35de"
+  integrity sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-gfm "^3.0.0"
+    micromark-extension-gfm "^3.0.0"
+    remark-parse "^11.0.0"
+    remark-stringify "^11.0.0"
+    unified "^11.0.0"
+
+remark-link-rewrite@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/remark-link-rewrite/-/remark-link-rewrite-1.0.7.tgz#c8b5ad3708b0a8f6dd93caeab4c4d4c3e7e0d3a4"
+  integrity sha512-jfmXL8VL3O7Ca4g+Ya0A0S9LIpVhCUSqMHiei4N8Z8Mx9z/oEI1HDoa1ZcF9/tS0I7NwydGsPkw2zT4eeoD6+Q==
+  dependencies:
+    unist-util-visit "^4.1.1"
+
+remark-mdx@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/remark-mdx/-/remark-mdx-3.1.0.tgz#f979be729ecb35318fa48e2135c1169607a78343"
+  integrity sha512-Ngl/H3YXyBV9RcRNdlYsZujAmhsxwzxpDzpDEhFBVAGthS4GDgnctpDjgFl/ULx5UEDzqtW1cyBSNKqYYrqLBA==
+  dependencies:
+    mdast-util-mdx "^3.0.0"
+    micromark-extension-mdxjs "^3.0.0"
+
+remark-parse@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-11.0.0.tgz#aa60743fcb37ebf6b069204eb4da304e40db45a1"
+  integrity sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-from-markdown "^2.0.0"
+    micromark-util-types "^2.0.0"
+    unified "^11.0.0"
+
+remark-stringify@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-11.0.0.tgz#4c5b01dd711c269df1aaae11743eb7e2e7636fd3"
+  integrity sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-to-markdown "^2.0.0"
+    unified "^11.0.0"
+
+remark@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-15.0.1.tgz#ac7e7563260513b66426bc47f850e7aa5862c37c"
+  integrity sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    remark-parse "^11.0.0"
+    remark-stringify "^11.0.0"
+    unified "^11.0.0"
+
 repeat-element@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
@@ -12952,7 +13819,7 @@ shell-quote@^1.6.1, shell-quote@^1.7.3:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.2.tgz#d2d83e057959d53ec261311e9e9b8f51dcb2934a"
   integrity sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==
 
-shelljs@^0.8.4, shelljs@^0.8.5:
+shelljs@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -13522,6 +14389,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-entities@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-4.0.4.tgz#b3b79ef5f277cc4ac73caeb0236c5ba939b3a4f3"
+  integrity sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+  dependencies:
+    character-entities-html4 "^2.0.0"
+    character-entities-legacy "^3.0.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -13928,6 +14803,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+to-vfile@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-8.0.0.tgz#4e1282bf251ce2beacae8e23a1752b3b3986bd29"
+  integrity sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==
+  dependencies:
+    vfile "^6.0.0"
+
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
@@ -13977,6 +14859,11 @@ trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+
+trough@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
+  integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
 ts-jest@^27.1.3:
   version "27.1.5"
@@ -14154,11 +15041,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc-default-themes@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
-  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
-
 typedoc-plugin-markdown@^3.11.14:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz#c33f42363c185adf842f4699166015f7fe0ed02b"
@@ -14166,22 +15048,21 @@ typedoc-plugin-markdown@^3.11.14:
   dependencies:
     handlebars "^4.7.7"
 
-typedoc@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
-  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
+typedoc-plugin-markdown@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.3.3.tgz#212f51faf742f8cc918e7ae239fd814b5b096317"
+  integrity sha512-kESCcNRzOcFJATLML2FoCfaTF9c0ujmbZ+UXsJvmNlFLS3v8tDKfDifreJXvXWa9d8gUcetZqOqFcZ/7+Ba34Q==
+
+typedoc-plugin-remark@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-remark/-/typedoc-plugin-remark-1.2.1.tgz#8517a7ae18bd9cdadbc62e20076f31a9f87db1fb"
+  integrity sha512-TZcijdMn6AOcGiIKebV2I6jlKuf8UTMFo2l3d7dTmoovG0x3Kdv69Dxdwb895YwJcQunI3V/VwCL5Pv3FZyHFw==
   dependencies:
-    fs-extra "^9.0.1"
-    handlebars "^4.7.6"
-    highlight.js "^10.2.0"
-    lodash "^4.17.20"
-    lunr "^2.3.9"
-    marked "^1.1.1"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    semver "^7.3.2"
-    shelljs "^0.8.4"
-    typedoc-default-themes "^0.11.4"
+    remark "^15.0.1"
+    remark-frontmatter "^5.0.0"
+    remark-gfm "^4.0.0"
+    remark-mdx "^3.1.0"
+    to-vfile "^8.0.0"
 
 typedoc@^0.22.13:
   version "0.22.18"
@@ -14194,10 +15075,26 @@ typedoc@^0.22.13:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
+typedoc@^0.27.5:
+  version "0.27.5"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.27.5.tgz#a86c89589213d7b36301eeafb4ddf6ad9dfd1ab3"
+  integrity sha512-x+fhKJtTg4ozXwKayh/ek4wxZQI/+2hmZUdO2i2NGDBRUflDble70z+ewHod3d4gRpXSO6fnlnjbDTnJk7HlkQ==
+  dependencies:
+    "@gerrit0/mini-shiki" "^1.24.0"
+    lunr "^2.3.9"
+    markdown-it "^14.1.0"
+    minimatch "^9.0.5"
+    yaml "^2.6.1"
+
 typescript@^4.6.2:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+uc.micro@^2.0.0, uc.micro@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 uglify-es@^3.1.9:
   version "3.3.9"
@@ -14270,6 +15167,19 @@ unicorn-magic@^0.3.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.3.0.tgz#4efd45c85a69e0dd576d25532fbfa22aa5c8a104"
   integrity sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==
 
+unified@^11.0.0:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
+  integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    bail "^2.0.0"
+    devlop "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^6.0.0"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -14321,6 +15231,68 @@ unique-string@^3.0.0:
   integrity sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==
   dependencies:
     crypto-random-string "^4.0.0"
+
+unist-util-is@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.2.1.tgz#b74960e145c18dcb6226bc57933597f5486deae9"
+  integrity sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
+unist-util-is@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.0.tgz#b775956486aff107a9ded971d996c173374be424"
+  integrity sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-position-from-estree@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz#d94da4df596529d1faa3de506202f0c9a23f2200"
+  integrity sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-stringify-position@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz#449c6e21a880e0855bf5aabadeb3a740314abac2"
+  integrity sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+
+unist-util-visit-parents@^5.1.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
+  integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
+unist-util-visit-parents@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz#4d5f85755c3b8f0dc69e21eca5d6d82d22162815"
+  integrity sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
+unist-util-visit@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
+  integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.1.1"
+
+unist-util-visit@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.0.0.tgz#a7de1f31f72ffd3519ea71814cccf5fd6a9217d6"
+  integrity sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.1"
@@ -14487,6 +15459,22 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vfile-message@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
+  integrity sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+
+vfile@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.3.tgz#3652ab1c496531852bf55a6bac57af981ebc38ab"
+  integrity sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile-message "^4.0.0"
 
 vlq@^1.0.0:
   version "1.0.1"
@@ -14894,6 +15882,11 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.1.tgz#42f2b1ba89203f374609572d5349fb8686500773"
+  integrity sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
@@ -14969,3 +15962,8 @@ yoctocolors@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.1.1.tgz#e0167474e9fbb9e8b3ecca738deaa61dd12e56fc"
   integrity sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==
+
+zwitch@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
+  integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION

If this works, reference documentation could be trivial to produce