### PR TITLE
fix(ios): Retrieving timeSensitive setting for iOS 15.0+

### DIFF
--- a/ios/NotifeeCore/NotifeeCore.m
+++ b/ios/NotifeeCore/NotifeeCore.m
@@ -706,6 +706,13 @@
           iosDictionary[@"inAppNotificationSettings"] = @-1;
         }
 
+        if (@available(iOS 15.0, *)) {
+          iosDictionary[@"timeSensitive"] =
+            [NotifeeCoreUtil numberForUNNotificationSetting:settings.timeSensitiveSetting];
+        } else {
+          iosDictionary[@"timeSensitive"] = @-1;
+        }
+
         iosDictionary[@"showPreviews"] = showPreviews;
         iosDictionary[@"authorizationStatus"] = authorizationStatus;
         iosDictionary[@"alert"] =

--- a/packages/react-native/src/types/NotificationIOS.ts
+++ b/packages/react-native/src/types/NotificationIOS.ts
@@ -360,6 +360,11 @@ export interface IOSNotificationSettings {
   criticalAlert: IOSNotificationSetting;
 
   /**
+   * Enum describing if time-sensitive notifications are entitled.
+   */
+  timeSensitive: IOSNotificationSetting;
+
+  /**
    * Enum describing if notification previews will be shown.
    */
   showPreviews: IOSShowPreviewsSetting;


### PR DESCRIPTION
# Hello 👋 

### This PR fixes: 
- #1194 

### What's changed:
- Added a a fetch for `timeSensitiveSetting` 
- Extended the `IOSNotificationSettings` interface 